### PR TITLE
Removed environment variables

### DIFF
--- a/templates/content/EmptyEventFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/EmptyEventFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.0",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "EmptyEventFunction::EmptyEventFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "EmptyEventFunction::EmptyEventFunction.Function::FunctionHandlerAsync"
 }

--- a/templates/content/EmptyRequestResponseFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/EmptyRequestResponseFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.1",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "EmptyRequestResponseFunction::EmptyRequestResponseFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "EmptyRequestResponseFunction::EmptyRequestResponseFunction.Function::FunctionHandlerAsync"
 }

--- a/templates/content/RichEventFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/RichEventFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.1",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "RichEventFunction::RichEventFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "RichEventFunction::RichEventFunction.Function::FunctionHandlerAsync"
 }

--- a/templates/content/RichRequestResponseFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/RichRequestResponseFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.1",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "RichRequestResponseFunction::RichRequestResponseFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "RichRequestResponseFunction::RichRequestResponseFunction.Function::FunctionHandlerAsync"
 }

--- a/templates/content/SnsEventFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/SnsEventFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.1",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "SnsEventFunction::SnsEventFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "SnsEventFunction::SnsEventFunction.Function::FunctionHandlerAsync"
 }

--- a/templates/content/SqsEventFunction/aws-lambda-tools-defaults.json
+++ b/templates/content/SqsEventFunction/aws-lambda-tools-defaults.json
@@ -17,6 +17,5 @@
   "function-runtime": "dotnetcore2.1",
   "function-memory-size": 128,
   "function-timeout": 30,
-  "function-handler": "SqsEventFunction::SqsEventFunction.Function::FunctionHandlerAsync",
-  "environment-variables": "Environment=;"
+  "function-handler": "SqsEventFunction::SqsEventFunction.Function::FunctionHandlerAsync"
 }


### PR DESCRIPTION
Environment variables that are manually set in AWS console resets for every deploy if the aws-lambda-tools-defaults.json file contains environment variables.