### PR TITLE
Allow customization of SNS and SQS serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ The best way to create a new AWS Lambda that uses this structure is to use the `
 
 Here is a list of all the available templates
 
-Name|Short name|Description
------|----------|------------
-Lambda Empty Event Function|lambda-template-event-empty|Creates an Event function with no extra setup
-Lambda Empty RequestResponse Function|lambda-template-requestresponse-empty|Creates a RequestResponse function with no extra setup
-Lambda Boilerplate Event Function|lambda-template-event-boilerplate|Creates an Event function with some boilerplate added
-Lambda Boilerplate RequestResponse Function|lambda-template-requestresponse-boilerplate|Creates a RequestResponse function with some boilerplate added
+|Name|Short name|Description|
+|-|-|-|
+|Lambda Empty Event Function|lambda-template-event-empty|Creates an Event function with no extra setup|
+|Lambda Empty RequestResponse Function|lambda-template-requestresponse-empty|Creates a RequestResponse function with no extra setup|
+|Lambda Boilerplate Event Function|lambda-template-event-boilerplate|Creates an Event function with some boilerplate added|
+|Lambda Boilerplate RequestResponse Function|lambda-template-requestresponse-boilerplate|Creates a RequestResponse function with some boilerplate added|
 
 All the templates support the following parameters
 * `--name|-n` Name of the project. It is also used as name of the function

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ public interface IEventHandler<TInput>
 ```
 [Here](https://github.com/Kralizek/AWSLambdaSharpTemplate/tree/master/samples/EventFunction) you can find a sample that shows an Event function that accepts an input string and logs it into CloudWatch logs.
 
+## Custom serializers
+
+You can pass a custom serializer to the Handler registration to override the default behavior of parsing all messages as JSON.
+```csharp
+
+public class CustomSerializer : ISerializer
+{
+	public T Deserialize<T>(string input)
+	{
+		// do some fancy 'serializing'
+		return JsonSerializer.Deserialize<T>(input);
+	}
+}
+
+// Function.cs
+private class DummyFunction : EventFunction<SQSEvent>
+{
+	protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
+	{
+		services.UseSqsHandler<SomeEvent, DummyHandler>(serializer: new CustomSerializer());
+	}
+}
+```
+
 # Creating a new function
 
 The best way to create a new AWS Lambda that uses this structure is to use the `dotnet new` template provided via NuGet.

--- a/samples/SnsEventFunctionWithParallelism/Function.cs
+++ b/samples/SnsEventFunctionWithParallelism/Function.cs
@@ -33,9 +33,7 @@ namespace SnsEventFunction
 
         protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
         {
-            services.ConfigureSnsParallelExecution(4);
-
-            services.UseNotificationHandler<CustomNotification, CustomNotificationHandler>(enableParallelExecution: true);
+            services.UseNotificationHandler<CustomNotification, CustomNotificationHandler>().WithParallelExecution(maxDegreeOfParallelism: 4);
         }
     }
 

--- a/src/Kralizek.Lambda.Template.Sns/INotificationSerializer.cs
+++ b/src/Kralizek.Lambda.Template.Sns/INotificationSerializer.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json;
+
+namespace Kralizek.Lambda
+{
+    public interface INotificationSerializer
+    {
+        public TMessage Deserialize<TMessage>(string input);
+    }
+
+    public class DefaultJsonNotificationSerializer : INotificationSerializer
+    {
+        public TMessage Deserialize<TMessage>(string input) => JsonSerializer.Deserialize<TMessage>(input);
+    }
+}

--- a/src/Kralizek.Lambda.Template.Sns/ParallelSnsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sns/ParallelSnsEventHandler.cs
@@ -37,7 +37,12 @@ namespace Kralizek.Lambda
                     using (var scope = _serviceProvider.CreateScope())
                     {
                         var message = record.Sns.Message;
-                        var notification = JsonSerializer.Deserialize<TNotification>(message);
+
+                        var serializer = _serviceProvider.GetService<ISerializer>();
+                        var notification = serializer != null
+                            ? serializer.Deserialize<TNotification>(message)
+                            : JsonSerializer.Deserialize<TNotification>(message);
+
                         _logger.LogDebug($"Message received: {message}");
 
                         var messageHandler = scope.ServiceProvider.GetService<INotificationHandler<TNotification>>();

--- a/src/Kralizek.Lambda.Template.Sns/ParallelSnsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sns/ParallelSnsEventHandler.cs
@@ -38,17 +38,15 @@ namespace Kralizek.Lambda
                     {
                         var message = record.Sns.Message;
 
-                        var serializer = _serviceProvider.GetService<ISerializer>();
-                        var notification = serializer != null
-                            ? serializer.Deserialize<TNotification>(message)
-                            : JsonSerializer.Deserialize<TNotification>(message);
+                        var serializer = _serviceProvider.GetRequiredService<INotificationSerializer>();
+                        var notification = serializer.Deserialize<TNotification>(message);
 
-                        _logger.LogDebug($"Message received: {message}");
+                        _logger.LogDebug("Message received: {Message}", message);
 
                         var messageHandler = scope.ServiceProvider.GetService<INotificationHandler<TNotification>>();
                         if (messageHandler == null)
                         {
-                            _logger.LogCritical($"No INotificationHandler<{typeof(TNotification).Name}> could be found.");
+                            _logger.LogCritical("No {Handler} could be found", $"INotificationHandler<{typeof(TNotification).Name}>");
                             throw new InvalidOperationException($"No INotificationHandler<{typeof(TNotification).Name}> could be found.");
                         }
                         

--- a/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
@@ -13,11 +13,14 @@ namespace Kralizek.Lambda
             return services;
         }
 
-        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
+        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution = false, ISerializer serializer = null)
             where TNotification : class
             where THandler : class, INotificationHandler<TNotification>
         {
             services.AddOptions();
+
+            if (serializer != null)
+                services.AddSingleton(sp => serializer);
 
             if (enableParallelExecution)
             {

--- a/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
@@ -13,14 +13,13 @@ namespace Kralizek.Lambda
             return services;
         }
 
-        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution = false, ISerializer serializer = null)
+        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
             where TNotification : class
             where THandler : class, INotificationHandler<TNotification>
         {
             services.AddOptions();
 
-            if (serializer != null)
-                services.AddSingleton(sp => serializer);
+            services.AddSingleton<INotificationSerializer, DefaultJsonNotificationSerializer>();
 
             if (enableParallelExecution)
             {

--- a/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sns/ServiceCollectionExtensions.cs
@@ -1,11 +1,13 @@
 using System;
 using Amazon.Lambda.SNSEvents;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Kralizek.Lambda
 {
     public static class ServiceCollectionExtensions
     {
+        [Obsolete("Use `services.UseNotificationHandler<TNotification,THandler>().UseParallelExecution(maxDegreeOfParallelism);` instead.")]
         public static IServiceCollection ConfigureSnsParallelExecution(this IServiceCollection services, int maxDegreeOfParallelism)
         {
             services.Configure<ParallelSnsExecutionOptions>(option => option.MaxDegreeOfParallelism = maxDegreeOfParallelism);
@@ -13,26 +15,80 @@ namespace Kralizek.Lambda
             return services;
         }
 
-        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
+        public static INotificationHandlerConfigurator<TNotification> WithParallelExecution<TNotification>(this INotificationHandlerConfigurator<TNotification> configurator, int? maxDegreeOfParallelism = null)
+            where TNotification : class
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
+
+            if (maxDegreeOfParallelism <= 1) throw new ArgumentOutOfRangeException(nameof(maxDegreeOfParallelism), $"{nameof(maxDegreeOfParallelism)} must be greater than 1");
+
+            configurator.Services.AddTransient<IEventHandler<SNSEvent>, ParallelSnsEventHandler<TNotification>>();
+
+            if (maxDegreeOfParallelism.HasValue)
+            {
+                configurator.Services.Configure<ParallelSnsExecutionOptions>(options => options.MaxDegreeOfParallelism = maxDegreeOfParallelism.Value);
+            }
+
+            return configurator;
+        }
+
+        public static IServiceCollection UseCustomNotificationSerializer<TSerializer>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TSerializer : INotificationSerializer
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            
+            services.Add(ServiceDescriptor.Describe(typeof(INotificationSerializer), typeof(TSerializer), lifetime));
+
+            return services;
+        }
+
+        [Obsolete("Use `services.UseNotificationHandler<TNotification,THandler>().UseParallelExecution();` instead.")]
+        public static IServiceCollection UseNotificationHandler<TNotification, THandler>(this IServiceCollection services, bool enableParallelExecution)
+            where TNotification : class
+            where THandler : class, INotificationHandler<TNotification>
+        {
+            var configurator = UseNotificationHandler<TNotification, THandler>(services);
+
+            if (enableParallelExecution)
+            {
+                configurator.WithParallelExecution();
+            }
+
+            return services;
+        }
+        
+        public static INotificationHandlerConfigurator<TNotification> UseNotificationHandler<TNotification, THandler>(this IServiceCollection services)
             where TNotification : class
             where THandler : class, INotificationHandler<TNotification>
         {
             services.AddOptions();
+            
+            services.AddTransient<IEventHandler<SNSEvent>, SnsEventHandler<TNotification>>();
 
-            services.AddSingleton<INotificationSerializer, DefaultJsonNotificationSerializer>();
-
-            if (enableParallelExecution)
-            {
-                services.AddTransient<IEventHandler<SNSEvent>, ParallelSnsEventHandler<TNotification>>();
-            }
-            else
-            {
-                services.AddTransient<IEventHandler<SNSEvent>, SnsEventHandler<TNotification>>();
-            }
+            services.TryAddSingleton<INotificationSerializer, DefaultJsonNotificationSerializer>();
 
             services.AddTransient<INotificationHandler<TNotification>, THandler>();
 
-            return services;            
+            var configurator = new NotificationHandlerConfigurator<TNotification>(services);
+
+            return configurator;
         }
+    }
+    
+    public interface INotificationHandlerConfigurator<TNotification>
+        where TNotification : class
+    {
+        IServiceCollection Services { get; }
+    }
+
+    internal sealed class NotificationHandlerConfigurator<TNotification> : INotificationHandlerConfigurator<TNotification>
+        where TNotification : class
+    {
+        public NotificationHandlerConfigurator(IServiceCollection services)
+        {
+            Services = services ?? throw new ArgumentNullException(nameof(services));
+        }
+        
+        public IServiceCollection Services { get; }
     }
 }

--- a/src/Kralizek.Lambda.Template.Sns/SnsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sns/SnsEventHandler.cs
@@ -29,16 +29,15 @@ namespace Kralizek.Lambda
                 {
                     var message = record.Sns.Message;
 
-                    var serializer = _serviceProvider.GetService<ISerializer>();
-                    var notification = serializer != null
-                        ? serializer.Deserialize<TNotification>(message)
-                        : JsonSerializer.Deserialize<TNotification>(message);
+                    var serializer = _serviceProvider.GetRequiredService<INotificationSerializer>();
+
+                    var notification = serializer.Deserialize<TNotification>(message);
                     
                     var handler = scope.ServiceProvider.GetService<INotificationHandler<TNotification>>();
 
                     if (handler == null)
                     {
-                        _logger.LogCritical($"No INotificationHandler<{typeof(TNotification).Name}> could be found.");
+                        _logger.LogCritical("No {Handler} could be found", $"INotificationHandler<{typeof(TNotification).Name}>");
                         throw new InvalidOperationException($"No INotificationHandler<{typeof(TNotification).Name}> could be found.");
                     }
 

--- a/src/Kralizek.Lambda.Template.Sns/SnsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sns/SnsEventHandler.cs
@@ -28,7 +28,11 @@ namespace Kralizek.Lambda
                 using (var scope = _serviceProvider.CreateScope())
                 {
                     var message = record.Sns.Message;
-                    var notification = JsonSerializer.Deserialize<TNotification>(message);
+
+                    var serializer = _serviceProvider.GetService<ISerializer>();
+                    var notification = serializer != null
+                        ? serializer.Deserialize<TNotification>(message)
+                        : JsonSerializer.Deserialize<TNotification>(message);
                     
                     var handler = scope.ServiceProvider.GetService<INotificationHandler<TNotification>>();
 

--- a/src/Kralizek.Lambda.Template.Sqs/IMessageSerializer.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/IMessageSerializer.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json;
+
+namespace Kralizek.Lambda
+{
+    public interface IMessageSerializer
+    {
+        public TMessage Deserialize<TMessage>(string input);
+    }
+
+    public class DefaultJsonMessageSerializer : IMessageSerializer
+    {
+        public TMessage Deserialize<TMessage>(string input) => JsonSerializer.Deserialize<TMessage>(input);
+    }
+}

--- a/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
@@ -12,14 +12,13 @@ namespace Kralizek.Lambda
             return services;
         }
 
-        public static IServiceCollection UseSqsHandler<TMessage, THandler>(this IServiceCollection services, bool enableParallelExecution = false, ISerializer serializer = null)
+        public static IServiceCollection UseSqsHandler<TMessage, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
             where TMessage : class
             where THandler : class, IMessageHandler<TMessage>
         {
             services.AddOptions();
 
-            if (serializer != null)
-                services.AddSingleton(sp => serializer);
+            services.AddSingleton<IMessageSerializer, DefaultJsonMessageSerializer>();
 
             if (enableParallelExecution)
             {

--- a/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
@@ -1,37 +1,94 @@
+using System;
 using Amazon.Lambda.SQSEvents;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Kralizek.Lambda
 {
     public static class ServiceCollectionExtensions
     {
+        [Obsolete("Use `services.UseQueueMessageHandler<TMessage,THandler>().UseParallelExecution(maxDegreeOfParallelism);` instead.")]
         public static IServiceCollection ConfigureSnsParallelExecution(this IServiceCollection services, int maxDegreeOfParallelism)
         {
             services.Configure<ParallelSqsExecutionOptions>(option => option.MaxDegreeOfParallelism = maxDegreeOfParallelism);
 
             return services;
         }
+        
+        public static IMessageHandlerConfigurator<TMessage> WithParallelExecution<TMessage>(this IMessageHandlerConfigurator<TMessage> configurator, int? maxDegreeOfParallelism = null)
+            where TMessage : class
+        {
+            ArgumentNullException.ThrowIfNull(configurator);
 
+            if (maxDegreeOfParallelism <= 1) throw new ArgumentOutOfRangeException(nameof(maxDegreeOfParallelism), $"{nameof(maxDegreeOfParallelism)} must be greater than 1");
+
+            configurator.Services.AddTransient<IEventHandler<SQSEvent>, ParallelSqsEventHandler<TMessage>>();
+
+            if (maxDegreeOfParallelism.HasValue)
+            {
+                configurator.Services.Configure<ParallelSqsExecutionOptions>(options => options.MaxDegreeOfParallelism = maxDegreeOfParallelism.Value);
+            }
+
+            return configurator;
+        }
+        
+        public static IServiceCollection UseCustomMessageSerializer<TSerializer>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TSerializer : IMessageSerializer
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            
+            services.Add(ServiceDescriptor.Describe(typeof(IMessageSerializer), typeof(TSerializer), lifetime));
+
+            return services;
+        }
+
+        [Obsolete("Use `services.UseQueueMessageHandler<TMessage, THandler>();` instead.")]
         public static IServiceCollection UseSqsHandler<TMessage, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
             where TMessage : class
             where THandler : class, IMessageHandler<TMessage>
         {
-            services.AddOptions();
-
-            services.AddSingleton<IMessageSerializer, DefaultJsonMessageSerializer>();
+            var configurator = UseQueueMessageHandler<TMessage, THandler>(services);
 
             if (enableParallelExecution)
             {
-                services.AddTransient<IEventHandler<SQSEvent>, ParallelSqsEventHandler<TMessage>>();
+                configurator.WithParallelExecution();
             }
-            else
-            {
-                services.AddTransient<IEventHandler<SQSEvent>, SqsEventHandler<TMessage>>();
-            }
-
-            services.AddTransient<IMessageHandler<TMessage>, THandler>();
 
             return services;
         }
+
+        public static IMessageHandlerConfigurator<TMessage> UseQueueMessageHandler<TMessage, THandler>(this IServiceCollection services)
+            where TMessage : class
+            where THandler : class, IMessageHandler<TMessage>
+        {
+            services.AddOptions();
+            
+            services.AddTransient<IEventHandler<SQSEvent>, SqsEventHandler<TMessage>>();
+            
+            services.TryAddSingleton<IMessageSerializer, DefaultJsonMessageSerializer>();
+
+            services.AddTransient<IMessageHandler<TMessage>, THandler>();
+
+            var configurator = new MessageHandlerConfigurator<TMessage>(services);
+
+            return configurator;
+        }
+    }
+
+    public interface IMessageHandlerConfigurator<TMessage>
+        where TMessage : class
+    {
+        IServiceCollection Services { get; }
+    }
+
+    internal sealed class MessageHandlerConfigurator<TMessage> : IMessageHandlerConfigurator<TMessage>
+        where TMessage : class
+    {
+        public MessageHandlerConfigurator(IServiceCollection services)
+        {
+            Services = services ?? throw new ArgumentNullException(nameof(services));
+        }
+        
+        public IServiceCollection Services { get; }
     }
 }

--- a/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/ServiceCollectionExtensions.cs
@@ -12,11 +12,14 @@ namespace Kralizek.Lambda
             return services;
         }
 
-        public static IServiceCollection UseSqsHandler<TMessage, THandler>(this IServiceCollection services, bool enableParallelExecution = false)
+        public static IServiceCollection UseSqsHandler<TMessage, THandler>(this IServiceCollection services, bool enableParallelExecution = false, ISerializer serializer = null)
             where TMessage : class
             where THandler : class, IMessageHandler<TMessage>
         {
             services.AddOptions();
+
+            if (serializer != null)
+                services.AddSingleton(sp => serializer);
 
             if (enableParallelExecution)
             {

--- a/src/Kralizek.Lambda.Template.Sqs/SqsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/SqsEventHandler.cs
@@ -26,7 +26,11 @@ namespace Kralizek.Lambda
                 using (var scope = _serviceProvider.CreateScope())
                 {
                     var sqsMessage = record.Body;
-                    var message = JsonSerializer.Deserialize<TMessage>(sqsMessage);
+
+                    var serializer = _serviceProvider.GetService<ISerializer>();
+                    var message = serializer != null
+                        ? serializer.Deserialize<TMessage>(sqsMessage)
+                        : JsonSerializer.Deserialize<TMessage>(sqsMessage);
 
                     var handler = scope.ServiceProvider.GetService<IMessageHandler<TMessage>>();
 

--- a/src/Kralizek.Lambda.Template.Sqs/SqsEventHandler.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/SqsEventHandler.cs
@@ -27,16 +27,15 @@ namespace Kralizek.Lambda
                 {
                     var sqsMessage = record.Body;
 
-                    var serializer = _serviceProvider.GetService<ISerializer>();
-                    var message = serializer != null
-                        ? serializer.Deserialize<TMessage>(sqsMessage)
-                        : JsonSerializer.Deserialize<TMessage>(sqsMessage);
+                    var serializer = _serviceProvider.GetRequiredService<IMessageSerializer>();
+                    
+                    var message = serializer.Deserialize<TMessage>(sqsMessage);
 
                     var handler = scope.ServiceProvider.GetService<IMessageHandler<TMessage>>();
 
                     if (handler == null)
                     {
-                        _logger.LogCritical($"No IMessageHandler<{typeof(TMessage).Name}> could be found.");
+                        _logger.LogError("No {Handler} could be found", $"IMessageHandler<{typeof(TMessage).Name}>");
                         throw new InvalidOperationException($"No IMessageHandler<{typeof(TMessage).Name}> could be found.");
                     }
 

--- a/src/Kralizek.Lambda.Template/EventFunction.cs
+++ b/src/Kralizek.Lambda.Template/EventFunction.cs
@@ -16,7 +16,7 @@ namespace Kralizek.Lambda
 
                 if (handler == null)
                 {
-                    Logger.LogCritical($"No IEventHandler<{typeof(TInput).Name}> could be found.");
+                    Logger.LogCritical("No {Handler} could be found", $"IEventHandler<{typeof(TInput).Name}>");
                     throw new InvalidOperationException($"No IEventHandler<{typeof(TInput).Name}> could be found.");
                 }
 
@@ -25,10 +25,8 @@ namespace Kralizek.Lambda
             }
         }
 
-        protected void RegisterHandler<THandler>(IServiceCollection services, ISerializer serializer = null) where THandler : class, IEventHandler<TInput>
+        protected void RegisterHandler<THandler>(IServiceCollection services) where THandler : class, IEventHandler<TInput>
         {
-            if (serializer != null)
-                services.AddSingleton(sp => serializer);
             services.AddTransient<IEventHandler<TInput>, THandler>();
         }
     }

--- a/src/Kralizek.Lambda.Template/EventFunction.cs
+++ b/src/Kralizek.Lambda.Template/EventFunction.cs
@@ -25,8 +25,10 @@ namespace Kralizek.Lambda
             }
         }
 
-        protected void RegisterHandler<THandler>(IServiceCollection services) where THandler : class, IEventHandler<TInput>
+        protected void RegisterHandler<THandler>(IServiceCollection services, ISerializer serializer = null) where THandler : class, IEventHandler<TInput>
         {
+            if (serializer != null)
+                services.AddSingleton(sp => serializer);
             services.AddTransient<IEventHandler<TInput>, THandler>();
         }
     }

--- a/src/Kralizek.Lambda.Template/ISerializer.cs
+++ b/src/Kralizek.Lambda.Template/ISerializer.cs
@@ -1,7 +1,0 @@
-﻿namespace Kralizek.Lambda
-{
-    public interface ISerializer
-    {
-        public T Deserialize<T>(string input);
-    }
-}

--- a/src/Kralizek.Lambda.Template/ISerializer.cs
+++ b/src/Kralizek.Lambda.Template/ISerializer.cs
@@ -1,0 +1,7 @@
+﻿namespace Kralizek.Lambda
+{
+    public interface ISerializer
+    {
+        public T Deserialize<T>(string input);
+    }
+}

--- a/src/Kralizek.Lambda.Template/RequestResponseFunction.cs
+++ b/src/Kralizek.Lambda.Template/RequestResponseFunction.cs
@@ -26,8 +26,11 @@ namespace Kralizek.Lambda
             }
         }
 
-        protected void RegisterHandler<THandler>(IServiceCollection services) where THandler : class, IRequestResponseHandler<TInput, TOutput>
+        protected void RegisterHandler<THandler>(IServiceCollection services, ISerializer serializer = null) where THandler : class, IRequestResponseHandler<TInput, TOutput>
         {
+            if (serializer != null)
+                services.AddTransient(sp => serializer);
+
             services.AddTransient<IRequestResponseHandler<TInput, TOutput>, THandler>();
         }
     }

--- a/src/Kralizek.Lambda.Template/RequestResponseFunction.cs
+++ b/src/Kralizek.Lambda.Template/RequestResponseFunction.cs
@@ -16,7 +16,7 @@ namespace Kralizek.Lambda
 
                 if (handler == null)
                 {
-                    Logger.LogCritical($"No IRequestResponseHandler<{typeof(TInput).Name}, {typeof(TOutput).Name}> could be found.");
+                    Logger.LogCritical("No {Handler} could be found", $"IRequestResponseHandler<{typeof(TInput).Name}, {typeof(TOutput).Name}>");
                     throw new InvalidOperationException($"No IRequestResponseHandler<{typeof(TInput).Name}, {typeof(TOutput).Name}> could be found.");
                 }
 
@@ -26,11 +26,8 @@ namespace Kralizek.Lambda
             }
         }
 
-        protected void RegisterHandler<THandler>(IServiceCollection services, ISerializer serializer = null) where THandler : class, IRequestResponseHandler<TInput, TOutput>
-        {
-            if (serializer != null)
-                services.AddTransient(sp => serializer);
-
+        protected void RegisterHandler<THandler>(IServiceCollection services) where THandler : class, IRequestResponseHandler<TInput, TOutput>
+        { 
             services.AddTransient<IRequestResponseHandler<TInput, TOutput>, THandler>();
         }
     }

--- a/tests/Tests.Lambda.Template/CustomSerializerTests.cs
+++ b/tests/Tests.Lambda.Template/CustomSerializerTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SNSEvents;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+using Kralizek.Lambda;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text.Json;
+using NUnit.Framework;
+
+
+namespace Tests.Lambda
+{
+    [TestFixture]
+    public class CustomSerializerTests
+    {
+        [SetUp]
+        public void Initialize()
+        {
+            
+        }
+
+        private class SomeEvent
+        {
+            public string message { get; set; }
+        }
+
+        private class CustomSerializer : ISerializer
+        {
+            public T Deserialize<T>(string input)
+            {
+                // do some fancy 'serializing'
+                // use input parameter instead of the hardcoded value here
+                return JsonSerializer.Deserialize<T>("{\r\n\"message\": \"hello world topsecret injection from serializer\"\r\n}");
+            }
+        }
+
+        // Handlers
+        private class DummyHandler : IMessageHandler<SomeEvent>
+        {
+            public Task HandleAsync(SomeEvent evt, ILambdaContext context)
+            {
+                Assert.True(evt.message == "hello world topsecret injection from serializer");
+                return Task.CompletedTask;
+            }
+        }
+
+        private class DummyHandlerNoChanges : IMessageHandler<SomeEvent>
+        {
+            public Task HandleAsync(SomeEvent evt, ILambdaContext context)
+            {
+                Assert.True(evt.message == "hello world");
+                return Task.CompletedTask;
+            }
+        }
+
+        // Functions
+        private class DummyFunction : EventFunction<SQSEvent>
+        {
+            protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
+            {
+                services.UseSqsHandler<SomeEvent, DummyHandler>(serializer: new CustomSerializer());
+            }
+        }
+
+        private class DummyFunctionNoChanges : EventFunction<SQSEvent>
+        {
+            protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
+            {
+                services.UseSqsHandler<SomeEvent, DummyHandlerNoChanges>();
+            }
+        }
+
+        [Test]
+        public async Task HandleAsync_DeserializesCorrectly()
+        {
+            var instance = new DummyFunction();
+            await instance.FunctionHandlerAsync(new SQSEvent()
+            {
+                Records = new List<SQSEvent.SQSMessage>()
+                {
+                    new SQSEvent.SQSMessage()
+                    {
+                        // or xml.. or json.. or whatever you want
+                        Body = "{\r\n\"message\": \"hello world\"\r\n}"
+                    }
+                }
+            }, null);
+        }
+
+        [Test]
+        public async Task HandleAsync_DeserializesCorrectly_WithoutChanges()
+        {
+            var instance = new DummyFunctionNoChanges();
+            await instance.FunctionHandlerAsync(new SQSEvent()
+            {
+                Records = new List<SQSEvent.SQSMessage>()
+                {
+                    new SQSEvent.SQSMessage()
+                    {
+                        // or xml.. or json.. or whatever you want
+                        Body = "{\r\n\"message\": \"hello world\"\r\n}"
+                    }
+                }
+            }, null);
+        }
+    }
+}

--- a/tests/Tests.Lambda.Template/CustomSerializerTests.cs
+++ b/tests/Tests.Lambda.Template/CustomSerializerTests.cs
@@ -64,7 +64,7 @@ namespace Tests.Lambda
         {
             protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
             {
-                services.UseSqsHandler<SomeEvent, DummyHandler>();
+                services.UseQueueMessageHandler<SomeEvent, DummyHandler>();
                 
                 services.AddSingleton<IMessageSerializer, CustomSerializer>();
             }
@@ -74,7 +74,7 @@ namespace Tests.Lambda
         {
             protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
             {
-                services.UseSqsHandler<SomeEvent, DummyHandlerNoChanges>();
+                services.UseQueueMessageHandler<SomeEvent, DummyHandlerNoChanges>();
             }
         }
 

--- a/tests/Tests.Lambda.Template/CustomSerializerTests.cs
+++ b/tests/Tests.Lambda.Template/CustomSerializerTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Lambda
             public string message { get; set; }
         }
 
-        private class CustomSerializer : ISerializer
+        private class CustomSerializer : IMessageSerializer
         {
             public T Deserialize<T>(string input)
             {
@@ -64,7 +64,9 @@ namespace Tests.Lambda
         {
             protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment)
             {
-                services.UseSqsHandler<SomeEvent, DummyHandler>(serializer: new CustomSerializer());
+                services.UseSqsHandler<SomeEvent, DummyHandler>();
+                
+                services.AddSingleton<IMessageSerializer, CustomSerializer>();
             }
         }
 
@@ -80,6 +82,7 @@ namespace Tests.Lambda
         public async Task HandleAsync_DeserializesCorrectly()
         {
             var instance = new DummyFunction();
+
             await instance.FunctionHandlerAsync(new SQSEvent()
             {
                 Records = new List<SQSEvent.SQSMessage>()

--- a/tests/Tests.Lambda.Template/Sns/ServiceCollectionExtensionsTests.cs
+++ b/tests/Tests.Lambda.Template/Sns/ServiceCollectionExtensionsTests.cs
@@ -53,5 +53,19 @@ namespace Tests.Lambda.Sns
 
             serviceProvider.GetRequiredService<INotificationHandler<TestNotification>>();
         }
+        
+        [Test]
+        public void UseNotificationHandler_registers_INotificationSerializer()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseNotificationHandler<TestNotification, TestNotificationHandler>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            serviceProvider.GetRequiredService<INotificationSerializer>();
+        }
     }
 }

--- a/tests/Tests.Lambda.Template/Sns/ServiceCollectionExtensionsTests.cs
+++ b/tests/Tests.Lambda.Template/Sns/ServiceCollectionExtensionsTests.cs
@@ -25,13 +25,31 @@ namespace Tests.Lambda.Sns
         }
 
         [Test]
+        public void UseNotificationHandler_registers_ParallelSnsEventHandler_when_parallel_execution_is_enabled_obsolete()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+#pragma warning disable CS0618
+            services.UseNotificationHandler<TestNotification, TestNotificationHandler>(enableParallelExecution: true);
+#pragma warning restore CS0618
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var handler = serviceProvider.GetRequiredService<IEventHandler<SNSEvent>>();
+
+            Assert.That(handler, Is.InstanceOf<ParallelSnsEventHandler<TestNotification>>());
+        }
+        
+        [Test]
         public void UseNotificationHandler_registers_ParallelSnsEventHandler_when_parallel_execution_is_enabled()
         {
             var services = new ServiceCollection();
 
             services.AddLogging();
 
-            services.UseNotificationHandler<TestNotification, TestNotificationHandler>(enableParallelExecution: true);
+            services.UseNotificationHandler<TestNotification, TestNotificationHandler>().WithParallelExecution();
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -66,6 +84,29 @@ namespace Tests.Lambda.Sns
             var serviceProvider = services.BuildServiceProvider();
 
             serviceProvider.GetRequiredService<INotificationSerializer>();
+        }
+
+        [Test]
+        public void UseCustomNotificationSerializer_registers_custom_serializer()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseNotificationHandler<TestNotification, TestNotificationHandler>();
+                
+            services.UseCustomNotificationSerializer<TestSerializer>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var serializer = serviceProvider.GetRequiredService<INotificationSerializer>();
+            
+            Assert.That(serializer, Is.InstanceOf<TestSerializer>());
+        }
+
+        private class TestSerializer : INotificationSerializer
+        {
+            public TMessage Deserialize<TMessage>(string input) => default;
         }
     }
 }

--- a/tests/Tests.Lambda.Template/Sns/SnsEventHandlerDisposalTests.cs
+++ b/tests/Tests.Lambda.Template/Sns/SnsEventHandlerDisposalTests.cs
@@ -52,8 +52,10 @@ namespace Tests.Lambda.Sns
                 TestNotificationScopedHandler>(provider =>
                 new TestNotificationScopedHandler(provider.GetRequiredService<DisposableDependency>(), tcs));
 
+            services.AddSingleton<INotificationSerializer, DefaultJsonNotificationSerializer>();
+
             var sp = services.BuildServiceProvider();
-            var snsEventHandler = new SnsEventHandler<TestNotification>(sp, new NullLoggerFactory());
+            var snsEventHandler = new SnsEventHandler<TestNotification>(sp, NullLoggerFactory.Instance);
 
             var task = snsEventHandler.HandleAsync(snsEvent, new TestLambdaContext());
 
@@ -103,8 +105,11 @@ namespace Tests.Lambda.Sns
 
             services.AddTransient<INotificationHandler<TestNotification>,
                 TestNotificationScopedHandler>(provider => new TestNotificationScopedHandler(provider.GetRequiredService<DisposableDependency>(), tcs));
+            
+            services.AddSingleton<INotificationSerializer, DefaultJsonNotificationSerializer>();
 
             var sp = services.BuildServiceProvider();
+
             var sqsEventHandler = new ParallelSnsEventHandler<TestNotification>(sp, new NullLoggerFactory(), Options.Create(new ParallelSnsExecutionOptions { MaxDegreeOfParallelism = 4 }));
 
             var task = sqsEventHandler.HandleAsync(snsEvent, new TestLambdaContext());

--- a/tests/Tests.Lambda.Template/Sqs/ServiceCollectionExtensionsTests.cs
+++ b/tests/Tests.Lambda.Template/Sqs/ServiceCollectionExtensionsTests.cs
@@ -70,5 +70,65 @@ namespace Tests.Lambda.Sqs
 
             serviceProvider.GetRequiredService<IMessageSerializer>();
         }
+        
+        [Test]
+        public void UseQueueMessageHandler_registers_default_SqsEventHandler()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseQueueMessageHandler<TestMessage, TestMessageHandler>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var handler = serviceProvider.GetRequiredService<IEventHandler<SQSEvent>>();
+
+            Assert.That(handler, Is.InstanceOf<SqsEventHandler<TestMessage>>());
+        }
+
+        [Test]
+        public void UseQueueMessageHandler_registers_ParallelSqsEventHandler_when_parallel_execution_is_enabled()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseQueueMessageHandler<TestMessage, TestMessageHandler>().WithParallelExecution();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var handler = serviceProvider.GetRequiredService<IEventHandler<SQSEvent>>();
+
+            Assert.That(handler, Is.InstanceOf<ParallelSqsEventHandler<TestMessage>>());
+        }
+
+        [Test]
+        public void UseQueueMessageHandler_registers_IMessageHandler()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseQueueMessageHandler<TestMessage, TestMessageHandler>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            serviceProvider.GetRequiredService<IMessageHandler<TestMessage>>();
+        }
+
+        [Test]
+        public void UseQueueMessageHandler_registers_IMessageSerializer()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseQueueMessageHandler<TestMessage, TestMessageHandler>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            serviceProvider.GetRequiredService<IMessageSerializer>();
+        }
     }
 }

--- a/tests/Tests.Lambda.Template/Sqs/ServiceCollectionExtensionsTests.cs
+++ b/tests/Tests.Lambda.Template/Sqs/ServiceCollectionExtensionsTests.cs
@@ -56,5 +56,19 @@ namespace Tests.Lambda.Sqs
 
             serviceProvider.GetRequiredService<IMessageHandler<TestMessage>>();
         }
+
+        [Test]
+        public void UseSqsHandler_registers_IMessageSerializer()
+        {
+            var services = new ServiceCollection();
+
+            services.AddLogging();
+
+            services.UseSqsHandler<TestMessage, TestMessageHandler>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            serviceProvider.GetRequiredService<IMessageSerializer>();
+        }
     }
 }

--- a/tests/Tests.Lambda.Template/Sqs/SqsEventHandlerDisposalTests.cs
+++ b/tests/Tests.Lambda.Template/Sqs/SqsEventHandlerDisposalTests.cs
@@ -45,6 +45,8 @@ namespace Tests.Lambda.Sqs
                 TestMessageScopedHandler>(provider =>
                 new TestMessageScopedHandler(provider.GetRequiredService<DisposableDependency>(), tcs));
 
+            services.AddSingleton<IMessageSerializer, DefaultJsonMessageSerializer>();
+
             var sp = services.BuildServiceProvider();
             var sqsEventHandler = new SqsEventHandler<TestMessage>(sp, new NullLoggerFactory());
 
@@ -91,6 +93,8 @@ namespace Tests.Lambda.Sqs
             services.AddTransient<IMessageHandler<TestMessage>,
                 TestMessageScopedHandler>(provider =>
                 new TestMessageScopedHandler(provider.GetRequiredService<DisposableDependency>(), tcs));
+            
+            services.AddSingleton<IMessageSerializer, DefaultJsonMessageSerializer>();
 
             var sp = services.BuildServiceProvider();
             var sqsEventHandler = new ParallelSqsEventHandler<TestMessage>(sp, new NullLoggerFactory(), Options.Create(new ParallelSqsExecutionOptions{MaxDegreeOfParallelism = 4}));

--- a/tests/Tests.Lambda.Template/Sqs/SqsEventHandlerTests.cs
+++ b/tests/Tests.Lambda.Template/Sqs/SqsEventHandlerTests.cs
@@ -14,6 +14,7 @@ namespace Tests.Lambda.Sqs {
     [TestFixture]
     public class SqsEventHandlerTests
     {
+        private Mock<IMessageSerializer> mockMessageSerializer;
         private Mock<IMessageHandler<TestMessage>> mockMessageHandler;
         private Mock<IServiceScopeFactory> mockServiceScopeFactory;
         private Mock<IServiceProvider> mockServiceProvider;
@@ -24,6 +25,12 @@ namespace Tests.Lambda.Sqs {
         [SetUp]
         public void Initialize()
         {
+            mockMessageSerializer = new Mock<IMessageSerializer>();
+
+            mockMessageSerializer
+                .Setup(p => p.Deserialize<TestMessage>(It.IsAny<string>()))
+                .Returns(() => new TestMessage());
+            
             mockMessageHandler = new Mock<IMessageHandler<TestMessage>>();
             mockMessageHandler.Setup(p => p.HandleAsync(It.IsAny<TestMessage>(), It.IsAny<ILambdaContext>())).Returns(Task.CompletedTask);
 
@@ -38,6 +45,10 @@ namespace Tests.Lambda.Sqs {
                                .Returns(mockMessageHandler.Object);
             mockServiceProvider.Setup(p => p.GetService(typeof(IServiceScopeFactory)))
                                .Returns(mockServiceScopeFactory.Object);
+
+            mockServiceProvider
+                .Setup(p => p.GetService(typeof(IMessageSerializer)))
+                .Returns(mockMessageSerializer.Object);
 
             mockServiceScope.Setup(p => p.ServiceProvider).Returns(mockServiceProvider.Object);
 


### PR DESCRIPTION
This PR allows the customization of the serializer used to read the incoming SQS message or SNS notification.

Credits to @Thomas-X for starting this in the PR #17 