### PR TITLE
Refine package release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      create_release:
+        description: Create a GitHub prerelease and attach packages
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -375,7 +381,7 @@ jobs:
           --skip-duplicate
 
       - name: Create alpha GitHub prerelease
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-
@@ -387,6 +393,7 @@ jobs:
           --prerelease
 
       - name: Attach packages to the GitHub release
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.create_release)
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,20 @@ name: CI
 on:
   push:
     branches: [master]
+    tags: [v*]
   pull_request: {}
-  release:
-    types: [published]
   workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref_type != 'tag' }}
 
 env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   CONFIGURATION: Release
   ARTIFACTS_PATH: ./artifacts
+  MinVerDefaultPreReleaseIdentifiers: ${{ github.event_name == 'workflow_dispatch' && 'alpha.0' || 'preview' }}
 
 jobs:
   validate-and-pack:
@@ -57,7 +57,7 @@ jobs:
         run: dotnet pack --configuration $CONFIGURATION --no-build --output $ARTIFACTS_PATH/packages
 
       - name: Upload packages
-        if: github.event_name == 'release'
+        if: github.event_name == 'workflow_dispatch' || github.ref_type == 'tag'
         uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
@@ -134,7 +134,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.ARTIFACTS_PATH }}/packages
-          key: smoke-packages-${{ runner.os }}-${{ github.sha }}
+          key: smoke-packages-${{ runner.os }}-${{ github.sha }}-${{ github.event_name }}
 
   template-smoke-test:
     name: Template smoke test (${{ matrix.name }})
@@ -215,7 +215,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.ARTIFACTS_PATH }}/packages
-          key: smoke-packages-${{ runner.os }}-${{ github.sha }}
+          key: smoke-packages-${{ runner.os }}-${{ github.sha }}-${{ github.event_name }}
           fail-on-cache-miss: true
 
       - name: Read package metadata
@@ -295,26 +295,83 @@ jobs:
   publish:
     name: Publish
     needs: [validate-and-pack, template-smoke-test]
-    if: github.event_name == 'release'
+    if: github.event_name == 'workflow_dispatch' || github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
       id-token: write
 
     steps:
+      - name: Validate manual release source
+        if: github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'
+        run: |
+          echo "Manual releases must be dispatched from master."
+          exit 1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
       - name: Download packages
         uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: ./artifacts/packages
 
+      - name: Read release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          package=$(ls ./artifacts/packages/Kralizek.Lambda.Templates.*.nupkg)
+          nuspec=$(unzip -p "$package" '*.nuspec')
+          package_version=$(printf '%s\n' "$nuspec" | sed -n 's:.*<version>\(.*\)</version>.*:\1:p' | head -n 1)
+
+          if [ -z "$package_version" ]; then
+            echo "Could not determine the package version."
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="v$package_version"
+          else
+            release_tag="${{ github.ref_name }}"
+            tag_version="${release_tag#v}"
+
+            if [ "$tag_version" != "$package_version" ]; then
+              echo "Tag version $tag_version does not match packed version $package_version."
+              exit 1
+            fi
+          fi
+
+          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+
+          if [[ "$package_version" == *-* ]]; then
+            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish to GitHub Packages
+        run: >-
+          dotnet nuget push
+          "./artifacts/packages/*.nupkg"
+          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --api-key "${{ github.token }}"
+          --skip-duplicate
+
       - name: Log in to NuGet.org
+        if: github.ref_type == 'tag'
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: Kralizek
 
       - name: Publish to NuGet.org
+        if: github.ref_type == 'tag'
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"
@@ -322,10 +379,35 @@ jobs:
           --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
           --skip-duplicate
 
+      - name: Create GitHub release if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists."
+            exit 0
+          fi
+
+          args=(
+            "$RELEASE_TAG"
+            --repo "${{ github.repository }}"
+            --target "$GITHUB_SHA"
+            --title "$RELEASE_TAG"
+            --generate-notes
+          )
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+
+          gh release create "${args[@]}"
+
       - name: Attach packages to the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: >-
           gh release upload "$RELEASE_TAG"
           ./artifacts/packages/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [master]
-    tags: [v*]
+    tags: ["v*"]
   pull_request: {}
   workflow_dispatch:
 
@@ -308,6 +308,11 @@ jobs:
         run: |
           echo "Manual releases must be dispatched from master."
           exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,21 @@ name: CI
 on:
   push:
     branches: [master]
-    tags: ["v*"]
   pull_request: {}
+  release:
+    types: [published]
   workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.ref_type != 'tag' }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release' }}
 
 env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   CONFIGURATION: Release
   ARTIFACTS_PATH: ./artifacts
-  MinVerDefaultPreReleaseIdentifiers: ${{ github.event_name == 'workflow_dispatch' && 'alpha.0' || 'preview' }}
+  MinVerDefaultPreReleaseIdentifiers: ${{ github.event_name == 'workflow_dispatch' && 'alpha' || 'preview' }}
 
 jobs:
   validate-and-pack:
@@ -57,7 +58,7 @@ jobs:
         run: dotnet pack --configuration $CONFIGURATION --no-build --output $ARTIFACTS_PATH/packages
 
       - name: Upload packages
-        if: github.event_name == 'workflow_dispatch' || github.ref_type == 'tag'
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
         uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
@@ -295,7 +296,7 @@ jobs:
   publish:
     name: Publish
     needs: [validate-and-pack, template-smoke-test]
-    if: github.event_name == 'workflow_dispatch' || github.ref_type == 'tag'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -308,11 +309,6 @@ jobs:
         run: |
           echo "Manual releases must be dispatched from master."
           exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -342,23 +338,17 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             release_tag="v$package_version"
           else
-            release_tag="${{ github.ref_name }}"
+            release_tag="${{ github.event.release.tag_name }}"
             tag_version="${release_tag#v}"
 
             if [ "$tag_version" != "$package_version" ]; then
-              echo "Tag version $tag_version does not match packed version $package_version."
+              echo "Release tag version $tag_version does not match packed version $package_version."
               exit 1
             fi
           fi
 
           echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
-
-          if [[ "$package_version" == *-* ]]; then
-            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
-          else
-            echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
-          fi
 
       - name: Publish to GitHub Packages
         run: >-
@@ -369,14 +359,14 @@ jobs:
           --skip-duplicate
 
       - name: Log in to NuGet.org
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'release'
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: Kralizek
 
       - name: Publish to NuGet.org
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'release'
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"
@@ -384,31 +374,17 @@ jobs:
           --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
           --skip-duplicate
 
-      - name: Create GitHub release if needed
+      - name: Create alpha GitHub prerelease
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists."
-            exit 0
-          fi
-
-          args=(
-            "$RELEASE_TAG"
-            --repo "${{ github.repository }}"
-            --target "$GITHUB_SHA"
-            --title "$RELEASE_TAG"
-            --generate-notes
-          )
-
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            args+=(--prerelease)
-          fi
-
-          gh release create "${args[@]}"
+        run: >-
+          gh release create "$RELEASE_TAG"
+          --repo "${{ github.repository }}"
+          --target "$GITHUB_SHA"
+          --title "$RELEASE_TAG"
+          --generate-notes
+          --prerelease
 
       - name: Attach packages to the GitHub release
         env:

--- a/eng/Package.props
+++ b/eng/Package.props
@@ -6,6 +6,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleaseIdentifiers>preview</MinVerDefaultPreReleaseIdentifiers>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
 
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Refine package publishing so validation and publishing have distinct release paths.

This PR:

- keeps ordinary pushes to `master` as build/test/template-smoke validation only, with no package artifact upload or publishing;
- lets `workflow_dispatch` publish an alpha package set from `master` to GitHub Packages without creating a GitHub Release by default;
- adds an opt-in `create_release` boolean input to `workflow_dispatch`; when enabled, the manual alpha run also creates the generated GitHub prerelease/tag and attaches `.nupkg`/`.snupkg` assets;
- keeps published GitHub Releases as the authoritative trigger for tagged publishing instead of reacting directly to raw tag pushes;
- for published releases, verifies the release tag matches the MinVer package version, publishes to both GitHub Packages and NuGet.org, and attaches package assets to the already-published release;
- keeps release artifacts sourced from the main `validate-and-pack` job while smoke tests repack independently;
- prevents release and manual-dispatch runs from being cancelled by normal concurrency handling;
- sets `MinVerMinimumMajorMinor` to `6.0`, so untagged builds start on the 6.0.0 line;
- uses `alpha` as MinVer's default prerelease identifier only for manually dispatched releases, while normal untagged builds keep the existing `preview` moniker.

The manual default is intentionally lightweight: publish an installable snapshot of `master` to GitHub Packages. Creating a durable GitHub prerelease is an explicit opt-in for cases where that alpha should be shared or referenced as a named release.