### PR TITLE
Allow manual alpha MinVer override

### DIFF
--- a/eng/Package.props
+++ b/eng/Package.props
@@ -4,7 +4,7 @@
     <Authors>Renato Golia</Authors>
 
     <MinVerTagPrefix>v</MinVerTagPrefix>
-    <MinVerDefaultPreReleaseIdentifiers>preview</MinVerDefaultPreReleaseIdentifiers>
+    <MinVerDefaultPreReleaseIdentifiers Condition="'$(MinVerDefaultPreReleaseIdentifiers)' == ''">preview</MinVerDefaultPreReleaseIdentifiers>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
     <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
 


### PR DESCRIPTION
Manual `workflow_dispatch` runs set `MinVerDefaultPreReleaseIdentifiers=alpha`, but `eng/Package.props` unconditionally resets the same MSBuild property to `preview`, causing manual releases to be packed and tagged as `6.0.0-preview.<height>`.

This PR makes `preview` a fallback only when `MinVerDefaultPreReleaseIdentifiers` has not already been supplied externally. That preserves the normal preview version for ordinary untagged builds while allowing manual dispatches to produce the intended `6.0.0-alpha.<height>` versions.

No other release behavior is changed.