### PR TITLE
Introduce composable record processing for nested Lambda events

### DIFF
--- a/AWSLambdaSharpTemplate.slnx
+++ b/AWSLambdaSharpTemplate.slnx
@@ -10,6 +10,8 @@
     <Project Path="samples/RequestFunction/RequestFunction.csproj" />
     <Project Path="samples/SnsFunction/SnsFunction.csproj" />
     <Project Path="samples/SqsFunction/SqsFunction.csproj" />
+    <Project Path="samples/SqsRawSnsS3Function/SqsRawSnsS3Function.csproj" />
+    <Project Path="samples/SqsSnsS3Function/SqsSnsS3Function.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Kralizek.Lambda.Template.Abstractions/Kralizek.Lambda.Template.Abstractions.csproj" />

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -8,6 +8,10 @@ The library separates three concerns:
 
 This avoids a single universal Lambda base class with source-specific switches. Source packages remain responsible for the semantics that genuinely differ: envelope mapping, metadata, decoding, ordering, retry behavior, and partial failure responses.
 
-The common runtime provides configuration, dependency injection, logging, cancellation, Lambda context mapping, scopes, and handler dispatch. The abstractions package contains source-neutral handler, context, and decoder contracts without depending on `Amazon.Lambda.Core`.
+The common runtime provides configuration, dependency injection, logging, cancellation, Lambda context mapping, scopes, and handler dispatch. The abstractions package contains source-neutral handler, context, decoder, and record-processing contracts without depending on `Amazon.Lambda.Core`.
+
+For record-oriented integrations, `RecordFunction<...>` owns the AWS invocation pipeline: envelope extraction, record scheduling, source-specific failure translation, result collection, and response generation. Execution of one record is delegated to `IRecordProcessor<TRecord, TRecordResult, TContext>`, which creates an independent record scope, resolves the registered record handler in that scope, invokes it, and disposes the scope.
+
+That split makes the framework's per-record lifetime semantics reusable when an application needs to compose nested record envelopes, without turning the processor into a second function pipeline. Scheduling, acknowledgement, checkpointing, and retry semantics remain owned by the outer source-specific function.
 
 Original AWS context and record objects are retained as explicit escape hatches rather than leaking into every application handler contract.

--- a/docs/Function-Contexts.md
+++ b/docs/Function-Contexts.md
@@ -11,3 +11,5 @@ The source-neutral contexts are:
 They expose common Lambda invocation metadata through CLR properties. Source-specific integrations derive richer contexts for delivery metadata, such as `SqsMessageContext`, `SnsNotificationContext`, `DynamoDbStreamRecordContext`, and `KinesisStreamRecordContext`.
 
 The original AWS Lambda context is preserved as an escape hatch and can be retrieved with `GetLambdaContext()`. Source-specific contexts similarly preserve the original AWS record where useful, for example `GetSqsMessage()`, `GetSnsRecord()`, and `GetDynamoDbStreamRecord()`.
+
+When record processing is composed, source-specific record contexts copy the parent context properties into the inner context. This is how outer delivery metadata remains available across nested record boundaries without relying on hierarchical dependency-injection scopes. For example, an S3 handler invoked for an S3 event carried by SQS can still recover the containing SQS message through `GetSqsMessage()`.

--- a/docs/Programming-Model.md
+++ b/docs/Programming-Model.md
@@ -10,4 +10,8 @@ Application behavior lives in handler classes resolved through dependency inject
 
 Source-specific packages layer AWS behavior on top of these roots. They own envelope mapping, source metadata, payload decoding where applicable, record-result semantics, and AWS-specific retry/failure responses.
 
+Record processing has one additional reusable primitive: `IRecordProcessor<TRecord, TRecordResult, TContext>`. A record processor executes exactly one record using the same per-record dependency-injection lifetime semantics used by `RecordFunction`: it creates an independent record scope, resolves the configured record handler, invokes it, and disposes the scope.
+
+Normal applications do not need to use a record processor directly. It exists for advanced composition scenarios where one delivered record contains another record-oriented envelope and the inner records should retain the framework's normal scope semantics. It does not own envelope iteration, parallelism, retry/checkpoint behavior, or the final Lambda response; those remain responsibilities of the source-specific function pipeline.
+
 Continue with [Event Functions](Event-Functions.md), [Request Functions](Request-Functions.md), or [Record Functions](Record-Functions.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ AWS Lambda Sharp Template provides .NET 10 runtime libraries and `dotnet new` te
 - New to the library? Read [Getting Started](Getting-Started.md).
 - Unsure which base type to use? Read [Choosing a Function Model](Choosing-a-Function-Model.md).
 - Migrating an existing application? Read [Migrating from v5 to v6](Migrating-from-v5-to-v6.md).
+- Composing nested record envelopes? Read [Record Processing](Record-Processing.md).
 
 ## AWS integrations
 
@@ -26,7 +27,7 @@ AWS Lambda Sharp Template provides .NET 10 runtime libraries and `dotnet new` te
 | Handle an input and return a result | `RequestFunction<TInput, TOutput, THandler>` | Request/response integrations such as Cognito |
 | Process independent records in an envelope | `RecordFunction<...>` | SQS, SNS, DynamoDB Streams, Kinesis Streams, S3 notifications, and other record sources |
 
-Source-specific packages specialize these roots while preserving a common model for dependency injection, configuration, logging, cancellation, contexts, and handler dispatch.
+Source-specific packages specialize these roots while preserving a common model for dependency injection, configuration, logging, cancellation, contexts, and handler dispatch. `IRecordProcessor<TRecord, TRecordResult, TContext>` exposes the single-record execution primitive for advanced nested-record composition while source-specific functions retain ownership of envelope scheduling and AWS failure semantics.
 
 ## Install the templates
 

--- a/docs/Record-Functions.md
+++ b/docs/Record-Functions.md
@@ -4,6 +4,10 @@ Record functions model Lambda invocations that contain multiple records. Source-
 
 The runtime creates an invocation scope plus an independent dependency-injection scope per record. Each source package also defines its own result type derived from `LambdaRecordResult`, allowing AWS-specific success and failure semantics without forcing all integrations into one common result contract.
 
-Applications should normally use the source-specific SQS, SNS, DynamoDB Streams, Kinesis Streams, or S3 function types rather than inheriting from `RecordFunction` directly.
+`RecordFunction<...>` owns the outer record pipeline: extracting records from the AWS envelope, selecting sequential or bounded-parallel scheduling, translating handler failures according to the event source, preserving each record/result association, and creating the final Lambda response.
 
-See [Record Processing](Record-Processing.md) for scopes, parallelism, result handling, and retry semantics.
+Execution of one record is delegated to `IRecordProcessor<TRecord, TRecordResult, TContext>`. The processor owns only the record-local lifetime: create a scope, resolve the registered record handler, invoke it, and dispose the scope. `RecordFunction` itself uses this processor, so nested record composition and top-level record functions share the same handler activation and scoping behavior.
+
+Applications should normally use the source-specific SQS, SNS, DynamoDB Streams, Kinesis Streams, or S3 function types rather than inheriting from `RecordFunction` directly. Direct use of `IRecordProcessor` is intended for advanced composition scenarios, such as an SQS message whose payload contains an S3 event with multiple inner records.
+
+See [Record Processing](Record-Processing.md) for scopes, composition, parallelism, result handling, and retry semantics.

--- a/docs/Record-Processing.md
+++ b/docs/Record-Processing.md
@@ -4,13 +4,29 @@ Record-oriented integrations share a common dispatch model while preserving sour
 
 ## Scopes
 
-A record invocation has one invocation scope plus an independent nested dependency-injection scope per record. Scoped handler dependencies therefore remain isolated between records.
+A record invocation has one invocation scope plus an independent dependency-injection scope per record. Scoped handler dependencies therefore remain isolated between records.
+
+The per-record lifetime is implemented by `IRecordProcessor<TRecord, TRecordResult, TContext>`. For each call to `ProcessAsync`, the processor creates a fresh scope, resolves the configured `IRecordHandler<TRecord, TRecordResult, TContext>` from that scope, invokes it, and disposes the scope.
+
+Microsoft dependency-injection scopes are not hierarchical. A nested record scope does not inherit scoped instances from an outer record or invocation scope. State that must cross a composition boundary should therefore travel explicitly through the framework context rather than through scoped services.
+
+## Nested record composition
+
+A record processor can be injected when a record payload contains another record-oriented envelope. For example, an SQS message may contain an S3 event with several S3 records. Dispatching each inner S3 record through the registered S3 record processor gives every inner record the same isolated handler scope it would receive in a direct S3 function.
+
+The processor intentionally handles only one record. The caller owns iteration of the nested envelope, while the outer `RecordFunction` continues to own scheduling, exception translation, and the AWS acknowledgement/checkpoint response.
+
+This means the AWS retry boundary does not move inward merely because an inner envelope is processed. If an inner S3 record throws while processing an SQS message, the exception propagates to the SQS record pipeline and the containing SQS message is the failed item. For fail-fast inner iteration, the remaining inner records in that message are skipped and will be retried with the containing message.
+
+Source packages may expose registration helpers that hide their internal adapters. For example, S3 exposes `AddS3ObjectEventProcessing<THandler>()` so composed pipelines can obtain the canonical S3 record processor while application code continues to implement `IS3ObjectEventHandler`.
 
 ## Sequential and parallel processing
 
 SQS and SNS expose sequential functions by default and bounded-parallel variants when concurrency inside an invocation is appropriate.
 
 DynamoDB Streams and Kinesis Streams deliberately process records sequentially. Increase throughput with the event source mapping's `ParallelizationFactor` rather than reordering work inside one batch. S3 notifications and S3 Batch Operations are also sequential in the current implementation.
+
+`IRecordProcessor` does not select a scheduling policy and does not provide a `ProcessManyAsync` API. Scheduling remains an envelope-level concern so source-specific ordering and retry semantics stay explicit.
 
 ## Results and failures
 

--- a/samples/DynamoDbStreamFunction/README.md
+++ b/samples/DynamoDbStreamFunction/README.md
@@ -72,7 +72,7 @@ The Lambda definition, role, packaging, and IAM permissions are omitted. `stream
 
 `Function` derives from `DynamoDbStreamFunction<OrderChangeHandler>`. The handler receives a `DynamoDbStreamItem` projection with keys, old/new images, sequence number, stream view type, and related metadata. The original AWS stream record remains available through `DynamoDbStreamRecordContext` when needed.
 
-Failed `DynamoDbStreamRecordResult` values are translated into `StreamsEventResponse` entries using sequence numbers.
+Each stream record is executed through `IRecordProcessor`, which creates its independent DI scope and resolves/invokes the stream record handler. The surrounding DynamoDB Streams function still owns sequential scheduling, sequence-number result translation, and the final `StreamsEventResponse`; the processor does not change stream ordering or checkpoint semantics.
 
 Records are deliberately processed sequentially inside one invocation. Increase throughput with the event source mapping's `ParallelizationFactor` rather than adding in-process parallelism, so shard ordering remains an infrastructure-level choice.
 

--- a/samples/KinesisStreamFunction/README.md
+++ b/samples/KinesisStreamFunction/README.md
@@ -70,7 +70,7 @@ KinesisEvent
 
 `Function` derives from `KinesisStreamFunction<OrderCreated, OrderCreatedHandler>`. The framework passes the record bytes through `IBinaryPayloadDecoder<OrderCreated>` before invoking the handler. The default decoder handles JSON, and applications can replace it through dependency injection.
 
-Failed `KinesisStreamRecordResult` values become `StreamsEventResponse` batch item failures using sequence numbers.
+The decoded stream record is executed through `IRecordProcessor`, which creates its independent DI scope and resolves/invokes the record handler. The Kinesis function remains responsible for sequential scheduling and translating source-specific results into `StreamsEventResponse` entries using sequence numbers.
 
 Records are deliberately processed sequentially inside one invocation. Increase concurrency through `ParallelizationFactor` on the event source mapping rather than reordering records inside the function.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,8 +10,10 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | --- | --- | --- |
 | A Lambda that consumes an event and returns no application response | [EventFunction](EventFunction/) | `EventFunction<TInput, THandler>`, handler DI, logging, and `EventContext` |
 | A Lambda with a typed request and response | [RequestFunction](RequestFunction/) | `RequestFunction<TInput, TOutput, THandler>` and `RequestContext` |
-| JSON messages from SQS | [SqsFunction](SqsFunction/) | typed payload decoding, per-record handlers, and partial batch failures |
+| JSON messages from SQS | [SqsFunction](SqsFunction/) | typed payload decoding, `IRecordProcessor`-backed per-record scopes, and partial batch failures |
 | SQS messages without decoding the body | [RawSqsFunction](RawSqsFunction/) | raw record handling when the AWS envelope is the application contract |
+| S3 notifications delivered through SNS → SQS with raw message delivery | [SqsRawSnsS3Function](SqsRawSnsS3Function/) | nested S3 record composition when the SQS body is the `S3Event` directly |
+| S3 notifications delivered through SNS → SQS with the SNS envelope preserved | [SqsSnsS3Function](SqsSnsS3Function/) | SNS-envelope decoding followed by nested S3 record composition |
 | JSON notifications from SNS | [SnsFunction](SnsFunction/) | typed payload decoding and SNS record handling |
 | SNS notifications without decoding the message | [RawSnsFunction](RawSnsFunction/) | raw SNS record handling |
 | A strongly typed EventBridge detail while retaining the full envelope | [EventBridgeFunction](EventBridgeFunction/) | `CloudWatchEvent<TDetail>` and EventBridge metadata |
@@ -29,6 +31,12 @@ Start with [EventFunction](EventFunction/) if the caller does not consume an app
 
 Compare [SqsFunction](SqsFunction/) with [RawSqsFunction](RawSqsFunction/), or [SnsFunction](SnsFunction/) with [RawSnsFunction](RawSnsFunction/). The decoded samples let the framework turn the message payload into an application type before invoking the handler. The raw samples keep the AWS record as the handler input when message attributes or the original envelope are central to the application logic.
 
+### Nested S3 notifications through SNS and SQS
+
+Compare [SqsRawSnsS3Function](SqsRawSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). The AWS topology is the same; the SNS subscription's `raw_message_delivery` setting changes the payload shape from `SQS body → S3Event` to `SQS body → SNS envelope → Message → S3Event`.
+
+Both samples use the public `IRecordProcessor` to reuse the framework's normal S3 per-record scope and handler-activation semantics inside an outer SQS record. The processor handles one inner record at a time; the outer SQS function remains responsible for iteration-level failure translation and the AWS retry boundary.
+
 ### Queues vs streams
 
 [SqsFunction](SqsFunction/) demonstrates record-oriented processing where bounded in-process parallelism can be an explicit specialization. [DynamoDbStreamFunction](DynamoDbStreamFunction/) and [KinesisStreamFunction](KinesisStreamFunction/) deliberately process records sequentially inside an invocation; use the Lambda event source mapping to control stream concurrency while preserving ordering semantics.
@@ -41,4 +49,4 @@ The projects use project references to the packages in this repository and are p
 dotnet build
 ```
 
-Each sample also contains `aws-lambda-tools-defaults.json` with example deployment settings. Treat those values as examples and replace profile, role, region, event-source configuration, and other infrastructure settings for your environment.
+Deployment-oriented samples may also contain `aws-lambda-tools-defaults.json` with example deployment settings. Treat those values as examples and replace profile, role, region, event-source configuration, and other infrastructure settings for your environment.

--- a/samples/RawSnsFunction/README.md
+++ b/samples/RawSnsFunction/README.md
@@ -57,7 +57,7 @@ resource "aws_lambda_permission" "sns" {
 
 `Function` derives from `SnsFunction<RawSnsRecordHandler>`. The handler receives the original SNS record, keeping the message, subject, message attributes, identifiers, and AWS metadata available directly.
 
-SNS still uses one handler invocation per record, but there is no partial-batch response protocol. An unhandled failure fails the Lambda invocation.
+SNS still uses one handler invocation per record. Under the hood, `IRecordProcessor` creates and disposes the independent scope for that record and resolves `RawSnsRecordHandler` inside it. The processor does not own SNS scheduling or failure semantics; those remain with the outer function pipeline. Because SNS has no partial-batch response protocol, an unhandled failure fails the Lambda invocation.
 
 ## Look at
 

--- a/samples/RawSqsFunction/README.md
+++ b/samples/RawSqsFunction/README.md
@@ -49,7 +49,7 @@ The Lambda packaging, role, and permissions are omitted. The important part is t
 
 `Function` derives from `SqsFunction<RawSqsRecordHandler>`. The handler receives the original `SQSEvent.SQSMessage`, so the body, message attributes, message ID, and AWS delivery metadata remain available directly.
 
-The record still participates in the normal SQS pipeline: one record scope per message, source-specific `SqsRecordResult` values, and partial-batch failure translation.
+The record still participates in the normal SQS pipeline. For each message, `IRecordProcessor` creates an independent record scope, resolves and invokes `RawSqsRecordHandler`, and disposes the scope before the function performs source-specific partial-batch failure translation. Applications normally interact only with the function and handler; the processor is the reusable single-record primitive underneath them.
 
 ## Look at
 

--- a/samples/SnsFunction/README.md
+++ b/samples/SnsFunction/README.md
@@ -61,7 +61,7 @@ SNSEvent
         └── OrderCreated
 ```
 
-`Function` derives from `SnsFunction<OrderCreated, OrderCreatedHandler>`. The framework decodes the notification message into `OrderCreated`, creates an independent record scope, and invokes the handler.
+`Function` derives from `SnsFunction<OrderCreated, OrderCreatedHandler>`. The framework decodes the notification message into `OrderCreated`, then delegates the record to `IRecordProcessor`, which creates the independent record scope and resolves/invokes the configured handler. Applications normally do not call the processor directly; it is the shared one-record execution primitive used by `RecordFunction` and advanced nested-record composition.
 
 Unlike SQS and stream integrations, SNS has no partial-batch response protocol. An unhandled failure therefore fails the Lambda invocation rather than returning failed item identifiers.
 

--- a/samples/SqsFunction/README.md
+++ b/samples/SqsFunction/README.md
@@ -52,7 +52,9 @@ SQSEvent
         └── OrderCreated
 ```
 
-`Function` derives from `SqsFunction<OrderCreated, OrderCreatedHandler>`. The SQS integration decodes each `SQSMessage.Body` into `OrderCreated`, creates an independent record scope, invokes the handler, and translates `SqsRecordResult` values into the Lambda partial-batch response.
+`Function` derives from `SqsFunction<OrderCreated, OrderCreatedHandler>`. The SQS integration decodes each `SQSMessage.Body` into `OrderCreated`, then the record pipeline delegates that record to `IRecordProcessor`, which creates an independent record scope, resolves and invokes the configured handler, and disposes the scope. The function translates `SqsRecordResult` values into the Lambda partial-batch response.
+
+Normal SQS functions do not need to resolve `IRecordProcessor` directly. The public processor becomes useful when composing nested record envelopes while preserving the same per-record scope semantics, as shown by the SQS → SNS → S3 samples.
 
 A failed record can therefore be reported without failing successful records from the same batch when the event source mapping enables partial batch responses.
 
@@ -62,4 +64,4 @@ A failed record can therefore be reported without failing successful records fro
 - `OrderCreated` for the decoded application payload.
 - `OrderCreatedHandler` for per-record processing and `SqsRecordResult`.
 
-If your application needs the original `SQSEvent.SQSMessage` rather than a decoded body, see [RawSqsFunction](../RawSqsFunction/).
+If your application needs the original `SQSEvent.SQSMessage` rather than a decoded body, see [RawSqsFunction](../RawSqsFunction/). For nested record composition, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/) and [SqsSnsS3Function](../SqsSnsS3Function/).

--- a/samples/SqsRawSnsS3Function/Function.cs
+++ b/samples/SqsRawSnsS3Function/Function.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace SqsRawSnsS3Function;
+
+public sealed class Function : SqsFunction<S3Event, S3DeliveryHandler>
+{
+    protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
+        services.TryAddScoped<S3EventDispatcher>();
+    }
+}
+
+public sealed class S3DeliveryHandler : ISqsMessageHandler<S3Event>
+{
+    private readonly S3EventDispatcher _dispatcher;
+
+    public S3DeliveryHandler(S3EventDispatcher dispatcher) => _dispatcher = dispatcher;
+
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        S3Event message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        await _dispatcher.DispatchAsync(message, context, cancellationToken).ConfigureAwait(false);
+        return SqsRecordResult.Success;
+    }
+}
+
+public sealed class S3EventDispatcher
+{
+    private readonly IRecordProcessor<
+        S3Event.S3EventNotificationRecord,
+        S3RecordResult,
+        RecordContext> _processor;
+
+    public S3EventDispatcher(
+        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> processor) =>
+        _processor = processor;
+
+    public async ValueTask DispatchAsync(
+        S3Event s3Event,
+        RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
+        {
+            await _processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+
+public sealed class S3ObjectEventHandler : IS3ObjectEventHandler
+{
+    private readonly ILogger<S3ObjectEventHandler> _logger;
+
+    public S3ObjectEventHandler(ILogger<S3ObjectEventHandler> logger) => _logger = logger;
+
+    public ValueTask HandleAsync(
+        S3ObjectEvent item,
+        S3RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sqsMessage = context.GetSqsMessage();
+
+        _logger.LogInformation(
+            "Handling S3 object {Bucket}/{Key} from SQS message {MessageId}",
+            item.Object.Bucket,
+            item.Object.Key,
+            sqsMessage.MessageId);
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/samples/SqsRawSnsS3Function/README.md
+++ b/samples/SqsRawSnsS3Function/README.md
@@ -1,41 +1,19 @@
-# SQS → SNS raw delivery → S3
+# SQS → SNS raw delivery → S3 sample
 
-This sample demonstrates processing S3 object notifications that reach Lambda through an SNS subscription to SQS with **Raw Message Delivery enabled**.
-
-The Lambda event source is SQS. SNS is part of the delivery topology, but because raw delivery is enabled the SNS JSON envelope is removed before the message is written to the queue. The SQS message body therefore contains the S3 event directly.
-
-```text
-S3 notification
-    ↓
-SNS topic
-    ↓ Raw Message Delivery
-SQS message body = S3Event JSON
-    ↓
-Lambda
-    ↓
-SqsFunction<S3Event, S3DeliveryHandler>
-    ↓
-S3EventDispatcher
-    ↓
-IRecordProcessor<S3EventNotificationRecord, S3RecordResult, RecordContext>
-    ↓
-IS3ObjectEventHandler
-```
-
-## Example infrastructure topology
-
-The sample assumes this AWS flow:
+Use this sample when S3 notifications are published to SNS, delivered to SQS with **Raw Message Delivery enabled**, and finally consumed by Lambda. It demonstrates nested record composition while keeping the normal S3 handler and per-record DI scope semantics.
 
 ```text
 S3 bucket
-  → SNS topic
+  → SNS topic (raw message delivery)
   → SQS queue
-  → Lambda
+  → SQSEvent
+  → SqsFunction<S3Event, S3DeliveryHandler>
+  → S3EventDispatcher
+  → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
+  → S3ObjectEventHandler
 ```
 
-The important detail is that the SNS subscription to SQS uses **Raw Message Delivery**. That causes the SQS message body to contain the serialized `S3Event` directly.
-
-A minimal Terraform sketch looks like this:
+## Minimal infrastructure
 
 ```hcl
 resource "aws_s3_bucket" "uploads" {
@@ -51,10 +29,9 @@ resource "aws_sqs_queue" "events" {
 }
 
 resource "aws_sns_topic_subscription" "sqs" {
-  topic_arn = aws_sns_topic.s3_events.arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.events.arn
-
+  topic_arn            = aws_sns_topic.s3_events.arn
+  protocol             = "sqs"
+  endpoint             = aws_sqs_queue.events.arn
   raw_message_delivery = true
 }
 
@@ -74,25 +51,18 @@ resource "aws_lambda_event_source_mapping" "events" {
 }
 ```
 
-A complete deployment also needs an SNS topic policy that allows S3 to publish, an SQS queue policy that allows the SNS topic to call `sqs:SendMessage`, and the usual Lambda packaging and permission resources. Those details are omitted so the sample stays focused on the event-processing topology.
+The Lambda definition and packaging are omitted, as are the SNS topic policy that permits S3 to publish and the SQS queue policy that permits the SNS topic to send messages. The important switch is `raw_message_delivery = true`: SNS removes its envelope before placing the message on SQS.
 
 ## Example Lambda input
 
-Because `raw_message_delivery = true`, the function receives an `SQSEvent` whose `Records[*].body` is already an `S3Event` JSON payload.
-
-A trimmed example looks like this:
+The SQS body contains the serialized S3 event directly:
 
 ```json
 {
   "Records": [
     {
       "messageId": "c5a3f4d9-9c33-4f9d-bd8e-4e3ab03b2c3f",
-      "receiptHandle": "...",
       "body": "{\"Records\":[{\"eventSource\":\"aws:s3\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"bucket\":{\"name\":\"example-uploads\"},\"object\":{\"key\":\"documents/report.pdf\",\"size\":12345}}}]}",
-      "attributes": {
-        "ApproximateReceiveCount": "1"
-      },
-      "messageAttributes": {},
       "eventSource": "aws:sqs",
       "eventSourceARN": "arn:aws:sqs:eu-north-1:123456789012:s3-events",
       "awsRegion": "eu-north-1"
@@ -111,112 +81,25 @@ SQSEvent
             └── S3 record
 ```
 
-That shape maps directly to:
+`Function` derives from `SqsFunction<S3Event, S3DeliveryHandler>`, so the outer SQS integration decodes `SQSMessage.Body` directly into `S3Event`.
 
-```csharp
-SqsFunction<S3Event, S3DeliveryHandler>
-```
+## How the pieces fit
 
-The SQS integration decodes the body directly into `S3Event`; no SNS-envelope decoding step is needed inside the function.
+`S3DeliveryHandler` handles one **outer SQS record**. It does not process S3 records itself; it passes the decoded `S3Event` to `S3EventDispatcher` and returns `SqsRecordResult.Success` only after all inner records succeed.
 
-## Function
+`S3EventDispatcher` expands `S3Event.Records` and calls `IRecordProcessor` once for each inner S3 record. Calling the S3 handler directly would make all inner records share the outer SQS handler scope; the processor instead creates an independent scope per S3 record, resolves the canonical S3 adapter and application handler inside it, invokes them, and disposes the scope.
 
-`Function` derives from:
+`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers that canonical S3 processing path. The application therefore continues to implement `IS3ObjectEventHandler`, just as it would for a Lambda triggered directly by S3.
 
-```csharp
-SqsFunction<S3Event, S3DeliveryHandler>
-```
+`S3ObjectEventHandler` receives `S3ObjectEvent` and `S3RecordContext`. The inner context copies the outer `RecordContext` properties, so `context.GetSqsMessage()` can recover the containing SQS message even though the inner S3 handler runs in a separate DI scope.
 
-The SQS integration therefore decodes each `SQSMessage.Body` directly into an AWS `S3Event`. There is no SNS-envelope decoder in this sample because Raw Message Delivery has already removed that envelope.
+Inner records are deliberately processed sequentially and fail fast. AWS acknowledges and retries the **outer SQS message**, not an individual S3 record hidden inside its body. An inner exception therefore marks the containing SQS message as failed while unrelated SQS messages in the same invocation can still succeed.
 
-`ConfigureServices` adds two pieces needed for the nested S3 pipeline:
+## Look at
 
-```csharp
-services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-services.TryAddScoped<S3EventDispatcher>();
-```
+- `Function` for S3 processor registration and the outer typed SQS specialization.
+- `S3DeliveryHandler` for the outer SQS acknowledgement boundary.
+- `S3EventDispatcher` for nested iteration through `IRecordProcessor`.
+- `S3ObjectEventHandler` for the normal S3 application-handler contract and propagated SQS context.
 
-`AddS3ObjectEventProcessing<THandler>()` registers the same S3 record-processing adapter used by a direct `S3Function<THandler>`. This is what lets the nested pipeline keep the normal `IS3ObjectEventHandler` programming model instead of reimplementing S3-specific context and object mapping inside the SQS handler.
-
-## S3DeliveryHandler
-
-`S3DeliveryHandler` is the handler for one **outer SQS record**:
-
-```csharp
-ISqsMessageHandler<S3Event>
-```
-
-At this point the SQS body has already been decoded into an `S3Event`. The handler does not process individual S3 records itself; it delegates the event to `S3EventDispatcher`.
-
-If every inner S3 record completes successfully, the handler returns `SqsRecordResult.Success` and the containing SQS message can be acknowledged normally.
-
-## S3EventDispatcher
-
-An `S3Event` can contain multiple S3 notification records. `S3EventDispatcher` expands that inner collection and sends each record through:
-
-```csharp
-IRecordProcessor<
-    S3Event.S3EventNotificationRecord,
-    S3RecordResult,
-    RecordContext>
-```
-
-The record processor is important here because simply resolving `S3ObjectEventHandler` from the SQS handler scope and calling it repeatedly would make every inner S3 record share the outer SQS record's scoped dependencies.
-
-Instead, every call to `ProcessAsync` creates an independent record scope, resolves the canonical S3 adapter and application handler inside that scope, invokes them, and disposes the scope. Inner S3 records therefore have the same per-record lifetime semantics they would have if Lambda were triggered directly by S3.
-
-The dispatcher deliberately processes inner S3 records sequentially. The outer SQS message is the AWS retry unit, so once one inner record fails the whole containing message must be retried. Continuing to execute later inner records would only increase the chance of duplicate side effects on that retry.
-
-## S3ObjectEventHandler
-
-`S3ObjectEventHandler` is ordinary application code:
-
-```csharp
-IS3ObjectEventHandler
-```
-
-It receives the synthetic `S3ObjectEvent` and an `S3RecordContext`, exactly like a direct S3 function would.
-
-The sample also demonstrates context propagation:
-
-```csharp
-var sqsMessage = context.GetSqsMessage();
-```
-
-`S3RecordContext` is created from the outer `RecordContext` and inherits its property bag. This allows the inner S3 handler to inspect the containing SQS message without depending on scoped services from the outer SQS record.
-
-## Scope model
-
-Microsoft dependency injection scopes are not hierarchical. The inner S3 record scopes are independent scopes backed by the same root container; they are not child scopes that inherit scoped instances from the SQS record scope.
-
-Conceptually:
-
-```text
-root container
-├── SQS record scope
-├── S3 record scope A
-├── S3 record scope B
-└── S3 record scope C
-```
-
-Outer delivery metadata is propagated explicitly through `RecordContext`, while scoped application dependencies remain isolated for every S3 record.
-
-## Failure and retry boundary
-
-AWS only knows about the SQS message delivered to Lambda. It does not know that the body contains several S3 records.
-
-If `S3ObjectEventHandler` throws while processing any inner record, that exception propagates back through `S3EventDispatcher` to the SQS record pipeline. The SQS integration then reports the **containing SQS message** as failed in the partial-batch response.
-
-Other SQS messages in the same Lambda invocation remain independent and can still succeed.
-
-```text
-SQS message A
-└── S3 record failure
-    → SQS message A failed
-
-SQS message B
-└── all S3 records succeed
-    → SQS message B succeeds
-```
-
-The SQS message, not an individual nested S3 record, is therefore the acknowledgement and retry boundary.
+For the same topology with the normal SNS JSON envelope preserved in SQS, compare [SqsSnsS3Function](../SqsSnsS3Function/).

--- a/samples/SqsRawSnsS3Function/README.md
+++ b/samples/SqsRawSnsS3Function/README.md
@@ -1,0 +1,222 @@
+# SQS → SNS raw delivery → S3
+
+This sample demonstrates processing S3 object notifications that reach Lambda through an SNS subscription to SQS with **Raw Message Delivery enabled**.
+
+The Lambda event source is SQS. SNS is part of the delivery topology, but because raw delivery is enabled the SNS JSON envelope is removed before the message is written to the queue. The SQS message body therefore contains the S3 event directly.
+
+```text
+S3 notification
+    ↓
+SNS topic
+    ↓ Raw Message Delivery
+SQS message body = S3Event JSON
+    ↓
+Lambda
+    ↓
+SqsFunction<S3Event, S3DeliveryHandler>
+    ↓
+S3EventDispatcher
+    ↓
+IRecordProcessor<S3EventNotificationRecord, S3RecordResult, RecordContext>
+    ↓
+IS3ObjectEventHandler
+```
+
+## Example infrastructure topology
+
+The sample assumes this AWS flow:
+
+```text
+S3 bucket
+  → SNS topic
+  → SQS queue
+  → Lambda
+```
+
+The important detail is that the SNS subscription to SQS uses **Raw Message Delivery**. That causes the SQS message body to contain the serialized `S3Event` directly.
+
+A minimal Terraform sketch looks like this:
+
+```hcl
+resource "aws_s3_bucket" "uploads" {
+  bucket = "example-uploads"
+}
+
+resource "aws_sns_topic" "s3_events" {
+  name = "s3-events"
+}
+
+resource "aws_sqs_queue" "events" {
+  name = "s3-events"
+}
+
+resource "aws_sns_topic_subscription" "sqs" {
+  topic_arn = aws_sns_topic.s3_events.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.events.arn
+
+  raw_message_delivery = true
+}
+
+resource "aws_s3_bucket_notification" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  topic {
+    topic_arn = aws_sns_topic.s3_events.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "events" {
+  event_source_arn        = aws_sqs_queue.events.arn
+  function_name           = aws_lambda_function.sample.arn
+  function_response_types = ["ReportBatchItemFailures"]
+}
+```
+
+A complete deployment also needs an SNS topic policy that allows S3 to publish, an SQS queue policy that allows the SNS topic to call `sqs:SendMessage`, and the usual Lambda packaging and permission resources. Those details are omitted so the sample stays focused on the event-processing topology.
+
+## Example Lambda input
+
+Because `raw_message_delivery = true`, the function receives an `SQSEvent` whose `Records[*].body` is already an `S3Event` JSON payload.
+
+A trimmed example looks like this:
+
+```json
+{
+  "Records": [
+    {
+      "messageId": "c5a3f4d9-9c33-4f9d-bd8e-4e3ab03b2c3f",
+      "receiptHandle": "...",
+      "body": "{\"Records\":[{\"eventSource\":\"aws:s3\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"bucket\":{\"name\":\"example-uploads\"},\"object\":{\"key\":\"documents/report.pdf\",\"size\":12345}}}]}",
+      "attributes": {
+        "ApproximateReceiveCount": "1"
+      },
+      "messageAttributes": {},
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-north-1:123456789012:s3-events",
+      "awsRegion": "eu-north-1"
+    }
+  ]
+}
+```
+
+Conceptually:
+
+```text
+SQSEvent
+└── SQSMessage
+    └── Body: S3Event
+        └── Records[]
+            └── S3 record
+```
+
+That shape maps directly to:
+
+```csharp
+SqsFunction<S3Event, S3DeliveryHandler>
+```
+
+The SQS integration decodes the body directly into `S3Event`; no SNS-envelope decoding step is needed inside the function.
+
+## Function
+
+`Function` derives from:
+
+```csharp
+SqsFunction<S3Event, S3DeliveryHandler>
+```
+
+The SQS integration therefore decodes each `SQSMessage.Body` directly into an AWS `S3Event`. There is no SNS-envelope decoder in this sample because Raw Message Delivery has already removed that envelope.
+
+`ConfigureServices` adds two pieces needed for the nested S3 pipeline:
+
+```csharp
+services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
+services.TryAddScoped<S3EventDispatcher>();
+```
+
+`AddS3ObjectEventProcessing<THandler>()` registers the same S3 record-processing adapter used by a direct `S3Function<THandler>`. This is what lets the nested pipeline keep the normal `IS3ObjectEventHandler` programming model instead of reimplementing S3-specific context and object mapping inside the SQS handler.
+
+## S3DeliveryHandler
+
+`S3DeliveryHandler` is the handler for one **outer SQS record**:
+
+```csharp
+ISqsMessageHandler<S3Event>
+```
+
+At this point the SQS body has already been decoded into an `S3Event`. The handler does not process individual S3 records itself; it delegates the event to `S3EventDispatcher`.
+
+If every inner S3 record completes successfully, the handler returns `SqsRecordResult.Success` and the containing SQS message can be acknowledged normally.
+
+## S3EventDispatcher
+
+An `S3Event` can contain multiple S3 notification records. `S3EventDispatcher` expands that inner collection and sends each record through:
+
+```csharp
+IRecordProcessor<
+    S3Event.S3EventNotificationRecord,
+    S3RecordResult,
+    RecordContext>
+```
+
+The record processor is important here because simply resolving `S3ObjectEventHandler` from the SQS handler scope and calling it repeatedly would make every inner S3 record share the outer SQS record's scoped dependencies.
+
+Instead, every call to `ProcessAsync` creates an independent record scope, resolves the canonical S3 adapter and application handler inside that scope, invokes them, and disposes the scope. Inner S3 records therefore have the same per-record lifetime semantics they would have if Lambda were triggered directly by S3.
+
+The dispatcher deliberately processes inner S3 records sequentially. The outer SQS message is the AWS retry unit, so once one inner record fails the whole containing message must be retried. Continuing to execute later inner records would only increase the chance of duplicate side effects on that retry.
+
+## S3ObjectEventHandler
+
+`S3ObjectEventHandler` is ordinary application code:
+
+```csharp
+IS3ObjectEventHandler
+```
+
+It receives the synthetic `S3ObjectEvent` and an `S3RecordContext`, exactly like a direct S3 function would.
+
+The sample also demonstrates context propagation:
+
+```csharp
+var sqsMessage = context.GetSqsMessage();
+```
+
+`S3RecordContext` is created from the outer `RecordContext` and inherits its property bag. This allows the inner S3 handler to inspect the containing SQS message without depending on scoped services from the outer SQS record.
+
+## Scope model
+
+Microsoft dependency injection scopes are not hierarchical. The inner S3 record scopes are independent scopes backed by the same root container; they are not child scopes that inherit scoped instances from the SQS record scope.
+
+Conceptually:
+
+```text
+root container
+├── SQS record scope
+├── S3 record scope A
+├── S3 record scope B
+└── S3 record scope C
+```
+
+Outer delivery metadata is propagated explicitly through `RecordContext`, while scoped application dependencies remain isolated for every S3 record.
+
+## Failure and retry boundary
+
+AWS only knows about the SQS message delivered to Lambda. It does not know that the body contains several S3 records.
+
+If `S3ObjectEventHandler` throws while processing any inner record, that exception propagates back through `S3EventDispatcher` to the SQS record pipeline. The SQS integration then reports the **containing SQS message** as failed in the partial-batch response.
+
+Other SQS messages in the same Lambda invocation remain independent and can still succeed.
+
+```text
+SQS message A
+└── S3 record failure
+    → SQS message A failed
+
+SQS message B
+└── all S3 records succeed
+    → SQS message B succeeds
+```
+
+The SQS message, not an individual nested S3 record, is therefore the acknowledgement and retry boundary.

--- a/samples/SqsRawSnsS3Function/SqsRawSnsS3Function.csproj
+++ b/samples/SqsRawSnsS3Function/SqsRawSnsS3Function.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.S3\Kralizek.Lambda.Template.S3.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.Sqs\Kralizek.Lambda.Template.Sqs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/SqsSnsS3Function/Function.cs
+++ b/samples/SqsSnsS3Function/Function.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace SqsSnsS3Function;
+
+public sealed class Function : SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+{
+    protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
+        services.TryAddScoped<S3EventDispatcher>();
+        services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
+    }
+}
+
+public sealed record SnsEnvelope
+{
+    public string Message { get; init; } = string.Empty;
+}
+
+public sealed class SnsEnvelopedS3DeliveryHandler : ISqsMessageHandler<SnsEnvelope>
+{
+    private readonly IStringPayloadDecoder<S3Event> _decoder;
+    private readonly S3EventDispatcher _dispatcher;
+
+    public SnsEnvelopedS3DeliveryHandler(
+        IStringPayloadDecoder<S3Event> decoder,
+        S3EventDispatcher dispatcher)
+    {
+        _decoder = decoder;
+        _dispatcher = dispatcher;
+    }
+
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        SnsEnvelope message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        var s3Event = await _decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
+        await _dispatcher.DispatchAsync(s3Event, context, cancellationToken).ConfigureAwait(false);
+        return SqsRecordResult.Success;
+    }
+}
+
+public sealed class S3EventDispatcher
+{
+    private readonly IRecordProcessor<
+        S3Event.S3EventNotificationRecord,
+        S3RecordResult,
+        RecordContext> _processor;
+
+    public S3EventDispatcher(
+        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> processor) =>
+        _processor = processor;
+
+    public async ValueTask DispatchAsync(
+        S3Event s3Event,
+        RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
+        {
+            await _processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+
+public sealed class S3ObjectEventHandler : IS3ObjectEventHandler
+{
+    private readonly ILogger<S3ObjectEventHandler> _logger;
+
+    public S3ObjectEventHandler(ILogger<S3ObjectEventHandler> logger) => _logger = logger;
+
+    public ValueTask HandleAsync(
+        S3ObjectEvent item,
+        S3RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var sqsMessage = context.GetSqsMessage();
+
+        _logger.LogInformation(
+            "Handling S3 object {Bucket}/{Key} from SNS via SQS message {MessageId}",
+            item.Object.Bucket,
+            item.Object.Key,
+            sqsMessage.MessageId);
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/samples/SqsSnsS3Function/README.md
+++ b/samples/SqsSnsS3Function/README.md
@@ -1,43 +1,20 @@
-# SQS → SNS envelope → S3
+# SQS → SNS envelope → S3 sample
 
-This sample demonstrates processing S3 object notifications that reach Lambda through an SNS subscription to SQS using the **standard SNS JSON envelope**.
-
-The Lambda event source is SQS. Unlike the raw-delivery sample, each SQS message body contains an SNS envelope, and the S3 event is serialized inside the envelope's `Message` property.
-
-```text
-S3 notification
-    ↓
-SNS topic
-    ↓ standard SNS delivery
-SQS message body = SNS envelope JSON
-    ↓
-Lambda
-    ↓
-SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
-    ↓
-decode SnsEnvelope.Message → S3Event
-    ↓
-S3EventDispatcher
-    ↓
-IRecordProcessor<S3EventNotificationRecord, S3RecordResult, RecordContext>
-    ↓
-IS3ObjectEventHandler
-```
-
-## Example infrastructure topology
-
-The sample assumes this AWS flow:
+Use this sample when S3 notifications are published to SNS, delivered to SQS using the **standard SNS JSON envelope**, and finally consumed by Lambda. It demonstrates the extra decoding layer plus nested S3 record composition.
 
 ```text
 S3 bucket
-  → SNS topic
+  → SNS topic (standard delivery)
   → SQS queue
-  → Lambda
+  → SQSEvent
+  → SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+  → decode SnsEnvelope.Message to S3Event
+  → S3EventDispatcher
+  → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
+  → S3ObjectEventHandler
 ```
 
-This sample differs from `SqsRawSnsS3Function` in one configuration detail only: the SNS subscription does **not** use Raw Message Delivery. That means the SQS message body contains the standard SNS envelope, and the S3 event is nested inside the envelope's `Message` property.
-
-A minimal Terraform sketch looks like this:
+## Minimal infrastructure
 
 ```hcl
 resource "aws_s3_bucket" "uploads" {
@@ -53,10 +30,9 @@ resource "aws_sqs_queue" "events" {
 }
 
 resource "aws_sns_topic_subscription" "sqs" {
-  topic_arn = aws_sns_topic.s3_events.arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.events.arn
-
+  topic_arn            = aws_sns_topic.s3_events.arn
+  protocol             = "sqs"
+  endpoint             = aws_sqs_queue.events.arn
   raw_message_delivery = false
 }
 
@@ -76,25 +52,18 @@ resource "aws_lambda_event_source_mapping" "events" {
 }
 ```
 
-A complete deployment also needs an SNS topic policy that allows S3 to publish, an SQS queue policy that allows the SNS topic to call `sqs:SendMessage`, and the usual Lambda packaging and permission resources. Those details are omitted so the sample stays focused on the event-processing topology.
+The Lambda definition and packaging are omitted, as are the SNS topic policy that permits S3 to publish and the SQS queue policy that permits SNS to send messages. The important difference from the raw-delivery sample is `raw_message_delivery = false`, which preserves the SNS envelope in `SQSMessage.Body`.
 
 ## Example Lambda input
 
-Because `raw_message_delivery = false`, the function receives an `SQSEvent` whose `Records[*].body` contains the SNS envelope rather than the `S3Event` directly.
-
-A trimmed example looks like this:
+The SQS body contains an SNS notification whose `Message` property contains the serialized S3 event:
 
 ```json
 {
   "Records": [
     {
       "messageId": "7f8c3ad7-3c2a-4dc6-95f4-bb6b0c6f0b52",
-      "receiptHandle": "...",
       "body": "{\"Type\":\"Notification\",\"MessageId\":\"2d402878-82d2-4c23-b5b9-6632f9f4fa71\",\"TopicArn\":\"arn:aws:sns:eu-north-1:123456789012:s3-events\",\"Message\":\"{\\\"Records\\\":[{\\\"eventSource\\\":\\\"aws:s3\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"s3\\\":{\\\"bucket\\\":{\\\"name\\\":\\\"example-uploads\\\"},\\\"object\\\":{\\\"key\\\":\\\"documents/report.pdf\\\",\\\"size\\\":12345}}}]}\"}",
-      "attributes": {
-        "ApproximateReceiveCount": "1"
-      },
-      "messageAttributes": {},
       "eventSource": "aws:sqs",
       "eventSourceARN": "arn:aws:sqs:eu-north-1:123456789012:s3-events",
       "awsRegion": "eu-north-1"
@@ -114,140 +83,28 @@ SQSEvent
                 └── S3 record
 ```
 
-That outer shape maps to:
+`Function` derives from `SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>`, so the outer SQS integration first decodes the body into the sample's minimal `SnsEnvelope` model.
 
-```csharp
-SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
-```
+## How the pieces fit
 
-The SQS integration decodes the body into `SnsEnvelope`. The handler then performs the second decoding step from `SnsEnvelope.Message` to `S3Event`.
+`SnsEnvelope` contains only the `Message` property because that is the only SNS metadata this sample needs. Applications can extend the model when they need more of the envelope.
 
-## Function
+`SnsEnvelopedS3DeliveryHandler` handles one **outer SQS record**. It uses `IStringPayloadDecoder<S3Event>` to decode `SnsEnvelope.Message`, then passes the resulting S3 event to `S3EventDispatcher`. This second decoding step is the main application difference from raw SNS delivery.
 
-`Function` derives from:
+`S3EventDispatcher` expands `S3Event.Records` and calls `IRecordProcessor` once for each inner S3 record. The processor gives every inner record its own DI scope and runs the same canonical S3 adapter/application-handler path used by direct S3 functions.
 
-```csharp
-SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
-```
+`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers that S3 record-processing path, while the explicit `IStringPayloadDecoder<S3Event>` registration handles the SNS `Message` string.
 
-The SQS integration first decodes each `SQSMessage.Body` into the local `SnsEnvelope` model. For this sample only the `Message` property is needed, so the model intentionally contains only that property rather than reproducing the complete SNS envelope.
+`S3ObjectEventHandler` remains an ordinary `IS3ObjectEventHandler`. Its `S3RecordContext` carries forward the outer context properties, so `context.GetSqsMessage()` can still recover the containing SQS message without sharing scoped services between the outer and inner handlers.
 
-`ConfigureServices` registers the nested S3 processing pieces:
+Inner S3 records are processed sequentially and fail fast. The AWS retry/acknowledgement boundary remains the outer SQS message: if one inner S3 record throws, the containing SQS message is reported as failed; unrelated SQS messages can still succeed.
 
-```csharp
-services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-services.TryAddScoped<S3EventDispatcher>();
-services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
-```
+## Look at
 
-`AddS3ObjectEventProcessing<THandler>()` exposes the same S3 record-processing composition used by direct S3 functions. The explicit `IStringPayloadDecoder<S3Event>` registration handles the second decoding layer: SNS stores the original S3 event as a string in `Message`.
+- `Function` for the outer SQS specialization, S3 processor registration, and S3 decoder registration.
+- `SnsEnvelope` for the minimal preserved SNS envelope.
+- `SnsEnvelopedS3DeliveryHandler` for the second decoding layer.
+- `S3EventDispatcher` for nested iteration through `IRecordProcessor`.
+- `S3ObjectEventHandler` for the normal S3 application-handler contract and propagated SQS context.
 
-## SnsEnvelope
-
-`SnsEnvelope` represents the outer SNS payload stored in the SQS body:
-
-```csharp
-public sealed record SnsEnvelope
-{
-    public string Message { get; init; } = string.Empty;
-}
-```
-
-It is deliberately minimal. The sample is concerned with nested record composition, not with modeling every SNS metadata property. Applications that need additional SNS metadata can extend this model accordingly.
-
-## SnsEnvelopedS3DeliveryHandler
-
-`SnsEnvelopedS3DeliveryHandler` handles one **outer SQS record** after the SQS body has been decoded into `SnsEnvelope`.
-
-Its first responsibility is to decode the SNS `Message` value into the actual S3 event:
-
-```csharp
-var s3Event = await _decoder.DecodeAsync(message.Message, cancellationToken);
-```
-
-It then delegates that S3 event to `S3EventDispatcher`.
-
-Only after all inner S3 records complete successfully does the handler return `SqsRecordResult.Success` for the containing SQS message.
-
-This extra decoder is the main difference from `SqsRawSnsS3Function`: with SNS Raw Message Delivery enabled, the SQS integration can decode the body directly as `S3Event` and this intermediate step disappears.
-
-## S3EventDispatcher
-
-An S3 event may contain several object-notification records. `S3EventDispatcher` expands the inner collection and processes each record through:
-
-```csharp
-IRecordProcessor<
-    S3Event.S3EventNotificationRecord,
-    S3RecordResult,
-    RecordContext>
-```
-
-The record processor preserves the framework's **one DI scope per record** invariant. Without it, a nested pipeline would either have to share the outer SQS record scope for all S3 records or duplicate the framework's scope creation and S3 handler activation logic.
-
-Each `ProcessAsync` call creates and disposes an independent S3 record scope and invokes the same S3 adapter/application-handler path used by a direct `S3Function<THandler>`.
-
-Inner records are processed sequentially on purpose. If one inner S3 record fails, AWS can only retry the outer SQS message. Processing later inner records after that failure would create additional side effects that may be repeated when the message is retried.
-
-## S3ObjectEventHandler
-
-`S3ObjectEventHandler` remains a normal:
-
-```csharp
-IS3ObjectEventHandler
-```
-
-The application handler does not need to know how many transport envelopes were crossed before the event reached it. It receives an `S3ObjectEvent` plus `S3RecordContext`, just as it would for a direct S3-triggered Lambda.
-
-The context also retains the outer SQS metadata:
-
-```csharp
-var sqsMessage = context.GetSqsMessage();
-```
-
-The S3 adapter creates its context from the outer `RecordContext` and copies the parent's property bag. This explicit context propagation lets the inner handler inspect the containing SQS message without coupling nested processing to DI scope inheritance.
-
-## Scope model
-
-Microsoft dependency injection does not provide hierarchical scopes. The SQS record scope and each nested S3 record scope are independent scopes backed by the same root container.
-
-```text
-root container
-├── SQS record scope
-├── S3 record scope A
-├── S3 record scope B
-└── S3 record scope C
-```
-
-Scoped dependencies do not flow from the SQS handler into the S3 handlers. Delivery metadata that must survive the transition is propagated through `RecordContext` instead.
-
-This is intentional: an S3 application handler gets the same scoped-lifetime behavior regardless of whether S3 invokes Lambda directly or its event arrives nested inside SNS and SQS.
-
-## Failure and retry boundary
-
-There are three logical layers in the payload, but only one AWS event-source acknowledgement boundary for this Lambda: SQS.
-
-```text
-SQS message
-└── SNS envelope
-    └── S3Event
-        ├── S3 record A
-        ├── S3 record B
-        └── S3 record C
-```
-
-If processing any inner S3 record throws, the exception propagates through the dispatcher and the outer SQS handler. The SQS integration then puts the **containing SQS message** in `SQSBatchResponse.batchItemFailures`.
-
-An individual nested S3 record cannot be retried independently because AWS Lambda received only the SQS record. Unrelated SQS messages in the same invocation remain independent and can still be acknowledged successfully.
-
-## Why this sample exists separately from the raw-delivery sample
-
-Both samples intentionally duplicate the small dispatcher and S3 application handler so each project can be read on its own.
-
-The difference between them is the transport shape before S3 record processing begins:
-
-```text
-Raw delivery:      SQS body → S3Event
-Standard delivery: SQS body → SNS envelope → Message → S3Event
-```
-
-From `S3EventDispatcher` onward, both use the same `IRecordProcessor` composition model and the same `IS3ObjectEventHandler` application contract.
+For the same topology with SNS Raw Message Delivery enabled, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/). The infrastructure difference is essentially one subscription setting; the payload and decoding path are what change.

--- a/samples/SqsSnsS3Function/README.md
+++ b/samples/SqsSnsS3Function/README.md
@@ -1,0 +1,253 @@
+# SQS → SNS envelope → S3
+
+This sample demonstrates processing S3 object notifications that reach Lambda through an SNS subscription to SQS using the **standard SNS JSON envelope**.
+
+The Lambda event source is SQS. Unlike the raw-delivery sample, each SQS message body contains an SNS envelope, and the S3 event is serialized inside the envelope's `Message` property.
+
+```text
+S3 notification
+    ↓
+SNS topic
+    ↓ standard SNS delivery
+SQS message body = SNS envelope JSON
+    ↓
+Lambda
+    ↓
+SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+    ↓
+decode SnsEnvelope.Message → S3Event
+    ↓
+S3EventDispatcher
+    ↓
+IRecordProcessor<S3EventNotificationRecord, S3RecordResult, RecordContext>
+    ↓
+IS3ObjectEventHandler
+```
+
+## Example infrastructure topology
+
+The sample assumes this AWS flow:
+
+```text
+S3 bucket
+  → SNS topic
+  → SQS queue
+  → Lambda
+```
+
+This sample differs from `SqsRawSnsS3Function` in one configuration detail only: the SNS subscription does **not** use Raw Message Delivery. That means the SQS message body contains the standard SNS envelope, and the S3 event is nested inside the envelope's `Message` property.
+
+A minimal Terraform sketch looks like this:
+
+```hcl
+resource "aws_s3_bucket" "uploads" {
+  bucket = "example-uploads"
+}
+
+resource "aws_sns_topic" "s3_events" {
+  name = "s3-events"
+}
+
+resource "aws_sqs_queue" "events" {
+  name = "s3-events"
+}
+
+resource "aws_sns_topic_subscription" "sqs" {
+  topic_arn = aws_sns_topic.s3_events.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.events.arn
+
+  raw_message_delivery = false
+}
+
+resource "aws_s3_bucket_notification" "uploads" {
+  bucket = aws_s3_bucket.uploads.id
+
+  topic {
+    topic_arn = aws_sns_topic.s3_events.arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "events" {
+  event_source_arn        = aws_sqs_queue.events.arn
+  function_name           = aws_lambda_function.sample.arn
+  function_response_types = ["ReportBatchItemFailures"]
+}
+```
+
+A complete deployment also needs an SNS topic policy that allows S3 to publish, an SQS queue policy that allows the SNS topic to call `sqs:SendMessage`, and the usual Lambda packaging and permission resources. Those details are omitted so the sample stays focused on the event-processing topology.
+
+## Example Lambda input
+
+Because `raw_message_delivery = false`, the function receives an `SQSEvent` whose `Records[*].body` contains the SNS envelope rather than the `S3Event` directly.
+
+A trimmed example looks like this:
+
+```json
+{
+  "Records": [
+    {
+      "messageId": "7f8c3ad7-3c2a-4dc6-95f4-bb6b0c6f0b52",
+      "receiptHandle": "...",
+      "body": "{\"Type\":\"Notification\",\"MessageId\":\"2d402878-82d2-4c23-b5b9-6632f9f4fa71\",\"TopicArn\":\"arn:aws:sns:eu-north-1:123456789012:s3-events\",\"Message\":\"{\\\"Records\\\":[{\\\"eventSource\\\":\\\"aws:s3\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"s3\\\":{\\\"bucket\\\":{\\\"name\\\":\\\"example-uploads\\\"},\\\"object\\\":{\\\"key\\\":\\\"documents/report.pdf\\\",\\\"size\\\":12345}}}]}\"}",
+      "attributes": {
+        "ApproximateReceiveCount": "1"
+      },
+      "messageAttributes": {},
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-north-1:123456789012:s3-events",
+      "awsRegion": "eu-north-1"
+    }
+  ]
+}
+```
+
+Conceptually:
+
+```text
+SQSEvent
+└── SQSMessage
+    └── Body: SNS envelope
+        └── Message: S3Event
+            └── Records[]
+                └── S3 record
+```
+
+That outer shape maps to:
+
+```csharp
+SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+```
+
+The SQS integration decodes the body into `SnsEnvelope`. The handler then performs the second decoding step from `SnsEnvelope.Message` to `S3Event`.
+
+## Function
+
+`Function` derives from:
+
+```csharp
+SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+```
+
+The SQS integration first decodes each `SQSMessage.Body` into the local `SnsEnvelope` model. For this sample only the `Message` property is needed, so the model intentionally contains only that property rather than reproducing the complete SNS envelope.
+
+`ConfigureServices` registers the nested S3 processing pieces:
+
+```csharp
+services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
+services.TryAddScoped<S3EventDispatcher>();
+services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
+```
+
+`AddS3ObjectEventProcessing<THandler>()` exposes the same S3 record-processing composition used by direct S3 functions. The explicit `IStringPayloadDecoder<S3Event>` registration handles the second decoding layer: SNS stores the original S3 event as a string in `Message`.
+
+## SnsEnvelope
+
+`SnsEnvelope` represents the outer SNS payload stored in the SQS body:
+
+```csharp
+public sealed record SnsEnvelope
+{
+    public string Message { get; init; } = string.Empty;
+}
+```
+
+It is deliberately minimal. The sample is concerned with nested record composition, not with modeling every SNS metadata property. Applications that need additional SNS metadata can extend this model accordingly.
+
+## SnsEnvelopedS3DeliveryHandler
+
+`SnsEnvelopedS3DeliveryHandler` handles one **outer SQS record** after the SQS body has been decoded into `SnsEnvelope`.
+
+Its first responsibility is to decode the SNS `Message` value into the actual S3 event:
+
+```csharp
+var s3Event = await _decoder.DecodeAsync(message.Message, cancellationToken);
+```
+
+It then delegates that S3 event to `S3EventDispatcher`.
+
+Only after all inner S3 records complete successfully does the handler return `SqsRecordResult.Success` for the containing SQS message.
+
+This extra decoder is the main difference from `SqsRawSnsS3Function`: with SNS Raw Message Delivery enabled, the SQS integration can decode the body directly as `S3Event` and this intermediate step disappears.
+
+## S3EventDispatcher
+
+An S3 event may contain several object-notification records. `S3EventDispatcher` expands the inner collection and processes each record through:
+
+```csharp
+IRecordProcessor<
+    S3Event.S3EventNotificationRecord,
+    S3RecordResult,
+    RecordContext>
+```
+
+The record processor preserves the framework's **one DI scope per record** invariant. Without it, a nested pipeline would either have to share the outer SQS record scope for all S3 records or duplicate the framework's scope creation and S3 handler activation logic.
+
+Each `ProcessAsync` call creates and disposes an independent S3 record scope and invokes the same S3 adapter/application-handler path used by a direct `S3Function<THandler>`.
+
+Inner records are processed sequentially on purpose. If one inner S3 record fails, AWS can only retry the outer SQS message. Processing later inner records after that failure would create additional side effects that may be repeated when the message is retried.
+
+## S3ObjectEventHandler
+
+`S3ObjectEventHandler` remains a normal:
+
+```csharp
+IS3ObjectEventHandler
+```
+
+The application handler does not need to know how many transport envelopes were crossed before the event reached it. It receives an `S3ObjectEvent` plus `S3RecordContext`, just as it would for a direct S3-triggered Lambda.
+
+The context also retains the outer SQS metadata:
+
+```csharp
+var sqsMessage = context.GetSqsMessage();
+```
+
+The S3 adapter creates its context from the outer `RecordContext` and copies the parent's property bag. This explicit context propagation lets the inner handler inspect the containing SQS message without coupling nested processing to DI scope inheritance.
+
+## Scope model
+
+Microsoft dependency injection does not provide hierarchical scopes. The SQS record scope and each nested S3 record scope are independent scopes backed by the same root container.
+
+```text
+root container
+├── SQS record scope
+├── S3 record scope A
+├── S3 record scope B
+└── S3 record scope C
+```
+
+Scoped dependencies do not flow from the SQS handler into the S3 handlers. Delivery metadata that must survive the transition is propagated through `RecordContext` instead.
+
+This is intentional: an S3 application handler gets the same scoped-lifetime behavior regardless of whether S3 invokes Lambda directly or its event arrives nested inside SNS and SQS.
+
+## Failure and retry boundary
+
+There are three logical layers in the payload, but only one AWS event-source acknowledgement boundary for this Lambda: SQS.
+
+```text
+SQS message
+└── SNS envelope
+    └── S3Event
+        ├── S3 record A
+        ├── S3 record B
+        └── S3 record C
+```
+
+If processing any inner S3 record throws, the exception propagates through the dispatcher and the outer SQS handler. The SQS integration then puts the **containing SQS message** in `SQSBatchResponse.batchItemFailures`.
+
+An individual nested S3 record cannot be retried independently because AWS Lambda received only the SQS record. Unrelated SQS messages in the same invocation remain independent and can still be acknowledged successfully.
+
+## Why this sample exists separately from the raw-delivery sample
+
+Both samples intentionally duplicate the small dispatcher and S3 application handler so each project can be read on its own.
+
+The difference between them is the transport shape before S3 record processing begins:
+
+```text
+Raw delivery:      SQS body → S3Event
+Standard delivery: SQS body → SNS envelope → Message → S3Event
+```
+
+From `S3EventDispatcher` onward, both use the same `IRecordProcessor` composition model and the same `IS3ObjectEventHandler` application contract.

--- a/samples/SqsSnsS3Function/SqsSnsS3Function.csproj
+++ b/samples/SqsSnsS3Function/SqsSnsS3Function.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.S3\Kralizek.Lambda.Template.S3.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.Sqs\Kralizek.Lambda.Template.Sqs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kralizek.Lambda.Template.Abstractions/HandlerContracts.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/HandlerContracts.cs
@@ -51,3 +51,18 @@ public interface IRecordHandler<in TRecord, TRecordResult, in TContext>
 {
     ValueTask<TRecordResult> HandleAsync(TRecord record, TContext context, CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// Processes one record using the framework record-scope and handler-activation semantics.
+/// </summary>
+/// <typeparam name="TRecord">The individual record type to process.</typeparam>
+/// <typeparam name="TRecordResult">The result produced from processing the record.</typeparam>
+/// <typeparam name="TContext">The context available while processing the record.</typeparam>
+#pragma warning disable S2436 // Record, result, and strongly typed context are distinct processor roles by design.
+public interface IRecordProcessor<in TRecord, TRecordResult, in TContext>
+#pragma warning restore S2436
+    where TRecordResult : LambdaRecordResult
+    where TContext : RecordContext
+{
+    ValueTask<TRecordResult> ProcessAsync(TRecord record, TContext context, CancellationToken cancellationToken);
+}

--- a/src/Kralizek.Lambda.Template.S3/S3Functions.cs
+++ b/src/Kralizek.Lambda.Template.S3/S3Functions.cs
@@ -23,6 +23,30 @@ public interface IS3BatchItemHandler
     ValueTask<S3BatchResult> HandleAsync(S3BatchItem item, S3BatchContext context, CancellationToken cancellationToken);
 }
 
+/// <summary>
+/// Registration helpers for composing S3 object-event record processing outside a direct S3 Lambda invocation.
+/// </summary>
+public static class S3ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers an S3 object-event handler and the record processor that adapts AWS S3 records to the public S3 programming model.
+    /// </summary>
+    public static IServiceCollection AddS3ObjectEventProcessing<THandler>(this IServiceCollection services)
+        where THandler : class, IS3ObjectEventHandler
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<THandler>();
+        services.AddRecordProcessor<
+            S3Event.S3EventNotificationRecord,
+            S3RecordResult,
+            RecordContext,
+            RawS3ObjectEventHandler<THandler>>();
+
+        return services;
+    }
+}
+
 [EditorBrowsable(EditorBrowsableState.Never)]
 public abstract class S3FunctionBase<TRecordHandler>
     : RecordFunction<S3Event, S3Event.S3EventNotificationRecord, S3RecordResult, object?, RecordContext, TRecordHandler>
@@ -68,7 +92,7 @@ public abstract class S3Function<THandler>
     protected override void ConfigureFrameworkServices(IServiceCollection services)
     {
         base.ConfigureFrameworkServices(services);
-        services.TryAddScoped<THandler>();
+        services.AddS3ObjectEventProcessing<THandler>();
     }
 }
 

--- a/src/Kralizek.Lambda.Template.Sqs/SqsMessageContext.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/SqsMessageContext.cs
@@ -96,9 +96,9 @@ public static class SqsMessageContextExtensions
     internal const string SqsMessagePropertyName = "Kralizek.Lambda.Template.Sqs.SqsMessage";
 
     /// <summary>
-    /// Gets the original AWS SQS message preserved in the context property bag.
+    /// Gets the original AWS SQS message preserved in this record context or one derived from it.
     /// </summary>
-    public static SQSEvent.SQSMessage GetSqsMessage(this SqsMessageContext context)
+    public static SQSEvent.SQSMessage GetSqsMessage(this RecordContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -107,6 +107,6 @@ public static class SqsMessageContextExtensions
             return message;
         }
 
-        throw new InvalidOperationException("The SQS message context does not contain an AWS SQS message.");
+        throw new InvalidOperationException("The record context does not contain an AWS SQS message.");
     }
 }

--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Amazon.Lambda.Core;
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Kralizek.Lambda;
 
@@ -30,7 +29,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
     protected override void ConfigureFrameworkServices(IServiceCollection services)
     {
         base.ConfigureFrameworkServices(services);
-        services.TryAddScoped<THandler>();
+        services.AddRecordProcessor<TRecord, TRecordResult, TContext, THandler>();
     }
 
     /// <summary>
@@ -98,13 +97,14 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         cancellationToken.ThrowIfCancellationRequested();
 
         var results = new List<RecordProcessingResult>();
+        var processor = invocationServices.GetRequiredService<IRecordProcessor<TRecord, TRecordResult, TContext>>();
 
         foreach (var record in GetRecords(envelope))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             var result = await ExecuteRecordAsync(
-                invocationServices,
+                processor,
                 record,
                 context,
                 cancellationToken).ConfigureAwait(false);
@@ -134,6 +134,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        var processor = invocationServices.GetRequiredService<IRecordProcessor<TRecord, TRecordResult, TContext>>();
         var records = GetRecords(envelope).ToArray();
         var results = new RecordProcessingResult[records.Length];
 
@@ -150,7 +151,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
             {
                 var record = records[index];
                 var result = await ExecuteRecordAsync(
-                    invocationServices,
+                    processor,
                     record,
                     context,
                     ct).ConfigureAwait(false);
@@ -162,22 +163,14 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
     }
 
     private async ValueTask<TRecordResult> ExecuteRecordAsync(
-        IServiceProvider invocationServices,
+        IRecordProcessor<TRecord, TRecordResult, TContext> processor,
         TRecord record,
         TContext context,
         CancellationToken cancellationToken)
     {
-        await using var recordScope = invocationServices.CreateAsyncScope();
-
         try
         {
-            var result = await ExecuteHandlerAsync<THandler, TRecordResult>(
-                recordScope.ServiceProvider,
-                cancellationToken,
-                (handler, ct) => handler.HandleAsync(record, context, ct)).ConfigureAwait(false);
-
-            return result ?? throw new InvalidOperationException(
-                $"Record handler {typeof(THandler).Name} returned a null result.");
+            return await processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/src/Kralizek.Lambda.Template/RecordProcessor.cs
+++ b/src/Kralizek.Lambda.Template/RecordProcessor.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Kralizek.Lambda;
+
+/// <summary>
+/// Registration helpers for record processors that reuse the framework record-scope semantics.
+/// </summary>
+public static class RecordProcessorServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a record handler together with a processor that creates an independent scope for every processed record.
+    /// </summary>
+#pragma warning disable S2436 // The generic roles mirror the record-processing model.
+    public static IServiceCollection AddRecordProcessor<TRecord, TRecordResult, TContext, THandler>(this IServiceCollection services)
+#pragma warning restore S2436
+        where TRecordResult : LambdaRecordResult
+        where TContext : RecordContext
+        where THandler : class, IRecordHandler<TRecord, TRecordResult, TContext>
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddScoped<THandler>();
+        services.TryAddSingleton<
+            IRecordProcessor<TRecord, TRecordResult, TContext>,
+            RecordProcessor<TRecord, TRecordResult, TContext, THandler>>();
+
+        return services;
+    }
+}
+
+#pragma warning disable S2436 // Record, result, context, and handler are distinct roles in the record-processing model.
+internal sealed class RecordProcessor<TRecord, TRecordResult, TContext, THandler>
+#pragma warning restore S2436
+    : IRecordProcessor<TRecord, TRecordResult, TContext>
+    where TRecordResult : LambdaRecordResult
+    where TContext : RecordContext
+    where THandler : class, IRecordHandler<TRecord, TRecordResult, TContext>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<RecordProcessor<TRecord, TRecordResult, TContext, THandler>> _logger;
+
+    public RecordProcessor(
+        IServiceScopeFactory scopeFactory,
+        ILogger<RecordProcessor<TRecord, TRecordResult, TContext, THandler>> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async ValueTask<TRecordResult> ProcessAsync(
+        TRecord record,
+        TContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await using var recordScope = _scopeFactory.CreateAsyncScope();
+        var handler = recordScope.ServiceProvider.GetRequiredService<THandler>();
+
+        _logger.LogDebug("Invoking handler {Handler}", typeof(THandler).Name);
+
+        var result = await handler.HandleAsync(record, context, cancellationToken).ConfigureAwait(false);
+
+        return result ?? throw new InvalidOperationException(
+            $"Record handler {typeof(THandler).Name} returned a null result.");
+    }
+}

--- a/tests/Tests.Lambda.Template/S3/NestedS3ProcessingTests.cs
+++ b/tests/Tests.Lambda.Template/S3/NestedS3ProcessingTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using NUnit.Framework;
+
+namespace Tests.Lambda.S3;
+
+[TestFixture]
+public class NestedS3ProcessingTests
+{
+    [SetUp]
+    public void SetUp() => NestedS3Handler.Reset();
+
+    [Test]
+    public async Task Nested_S3_records_get_independent_scopes_and_preserve_SQS_context()
+    {
+        var sqsEvent = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                CreateSqsMessage("message-1", "one.txt", "two.txt"),
+                CreateSqsMessage("message-2", "three.txt", "four.txt", "five.txt")
+            }
+        };
+
+        var response = await new NestedFunction().FunctionHandlerAsync(sqsEvent, TestLambdaContexts.Create());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.BatchItemFailures, Is.Empty);
+            Assert.That(NestedS3Handler.Received, Has.Count.EqualTo(5));
+            Assert.That(NestedS3Handler.Received.Select(x => x.ScopeId).Distinct().Count(), Is.EqualTo(5));
+            Assert.That(NestedS3Handler.Received.Count(x => x.SqsMessageId == "message-1"), Is.EqualTo(2));
+            Assert.That(NestedS3Handler.Received.Count(x => x.SqsMessageId == "message-2"), Is.EqualTo(3));
+        });
+    }
+
+    [Test]
+    public async Task Inner_S3_failure_marks_only_the_containing_SQS_message_as_failed()
+    {
+        NestedS3Handler.FailOnKey = "fail.txt";
+
+        var sqsEvent = new SQSEvent
+        {
+            Records = new List<SQSEvent.SQSMessage>
+            {
+                CreateSqsMessage("message-1", "before.txt", "fail.txt", "after.txt"),
+                CreateSqsMessage("message-2", "other.txt")
+            }
+        };
+
+        var response = await new NestedFunction().FunctionHandlerAsync(sqsEvent, TestLambdaContexts.Create());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(response.BatchItemFailures.Select(x => x.ItemIdentifier), Is.EqualTo(new[] { "message-1" }));
+            Assert.That(NestedS3Handler.Received.Select(x => x.Key), Is.EqualTo(new[] { "before.txt", "fail.txt", "other.txt" }));
+        });
+    }
+
+    private static SQSEvent.SQSMessage CreateSqsMessage(string messageId, params string[] keys) =>
+        new()
+        {
+            MessageId = messageId,
+            Body = JsonSerializer.Serialize(CreateS3Event(keys), new JsonSerializerOptions(JsonSerializerDefaults.Web))
+        };
+
+    private static S3Event CreateS3Event(IEnumerable<string> keys) =>
+        new()
+        {
+            Records = keys.Select(key => new S3Event.S3EventNotificationRecord
+            {
+                EventName = "ObjectCreated:Put",
+                EventTime = new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc),
+                S3 = new S3Event.S3Entity
+                {
+                    Bucket = new S3Event.S3BucketEntity { Name = "uploads" },
+                    Object = new S3Event.S3ObjectEntity { Key = key }
+                }
+            }).ToList()
+        };
+
+    private sealed class NestedFunction : SqsFunction<S3Event, NestedSqsHandler>
+    {
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddS3ObjectEventProcessing<NestedS3Handler>();
+            services.TryAddScoped<NestedDispatcher>();
+            services.TryAddScoped<ScopeMarker>();
+        }
+    }
+
+    private sealed class NestedSqsHandler : ISqsMessageHandler<S3Event>
+    {
+        private readonly NestedDispatcher _dispatcher;
+
+        public NestedSqsHandler(NestedDispatcher dispatcher) => _dispatcher = dispatcher;
+
+        public async ValueTask<SqsRecordResult> HandleAsync(
+            S3Event message,
+            SqsMessageContext context,
+            CancellationToken cancellationToken)
+        {
+            await _dispatcher.DispatchAsync(message, context, cancellationToken).ConfigureAwait(false);
+            return SqsRecordResult.Success;
+        }
+    }
+
+    private sealed class NestedDispatcher
+    {
+        private readonly IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> _processor;
+
+        public NestedDispatcher(
+            IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> processor) =>
+            _processor = processor;
+
+        public async ValueTask DispatchAsync(
+            S3Event s3Event,
+            RecordContext context,
+            CancellationToken cancellationToken)
+        {
+            foreach (var record in s3Event.Records)
+            {
+                await _processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private sealed class ScopeMarker
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private sealed class NestedS3Handler : IS3ObjectEventHandler
+    {
+        private static readonly List<ReceivedItem> Items = new();
+        private readonly ScopeMarker _scopeMarker;
+
+        public NestedS3Handler(ScopeMarker scopeMarker) => _scopeMarker = scopeMarker;
+
+        public static IReadOnlyCollection<ReceivedItem> Received => Items;
+        public static string? FailOnKey { get; set; }
+
+        public static void Reset()
+        {
+            Items.Clear();
+            FailOnKey = null;
+        }
+
+        public ValueTask HandleAsync(
+            S3ObjectEvent item,
+            S3RecordContext context,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Items.Add(new ReceivedItem(item.Object.Key, context.GetSqsMessage().MessageId!, _scopeMarker.Id));
+
+            if (item.Object.Key == FailOnKey)
+            {
+                throw new InvalidOperationException("Synthetic nested record failure.");
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed record ReceivedItem(string Key, string SqsMessageId, Guid ScopeId);
+}


### PR DESCRIPTION
Closes #49.

## What changed

- adds a public `IRecordProcessor<TRecord, TRecordResult, TContext>` composition contract;
- extracts record scope creation and handler activation into a reusable processor used by `RecordFunction` itself;
- adds `AddS3ObjectEventProcessing<THandler>()` so nested pipelines can reuse the same S3 adapter used by direct S3 functions without depending on hidden infrastructure types;
- allows propagated nested record contexts to recover their containing SQS message through `GetSqsMessage()`;
- adds two focused advanced samples:
  - `SqsRawSnsS3Function` for SNS raw message delivery (`SQS body -> S3Event`);
  - `SqsSnsS3Function` for SNS-enveloped delivery (`SQS body -> SNS envelope -> Message -> S3Event`);
- adds tests for independent per-inner-record scopes, SQS context propagation, fail-fast inner processing, and SQS partial-batch failure at the containing-message boundary;
- updates ADR #30 and the architecture/programming-model/record-processing/context documentation to define the processor's role and boundaries.

## Design outcome

The experiment exposed two concrete public API gaps: record handler contracts were composable but record scope/activation semantics were not, and preserved SQS metadata could not be read from a derived nested context. The changes are generic/source-level rather than topology-specific.

`RecordFunction` remains responsible for the AWS envelope pipeline: extraction, scheduling, source-specific exception translation, result association, and final response generation. `IRecordProcessor` deliberately owns only execution of one record: create its independent scope, resolve the configured handler, invoke it, and dispose the scope.

The outer SQS record remains the AWS acknowledgement/retry boundary. An inner S3 exception therefore marks the containing SQS message failed while unrelated SQS records continue through the normal partial-batch path.

## Validation

GitHub Actions and the SonarCloud quality gate were green before the documentation update. The latest documentation commits trigger a fresh validation run.