### PR TITLE
Refine prerelease versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,15 @@ on:
   workflow_dispatch:
     inputs:
       release_channel:
-        description: Prerelease channel to use when creating a GitHub prerelease
+        description: Prerelease channel to create, or none for a manual package build
         type: choice
         required: true
-        default: alpha
+        default: none
         options:
+          - none
           - alpha
           - beta
           - rc
-      create_release:
-        description: Create a GitHub prerelease and attach packages
-        type: boolean
-        required: false
-        default: false
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -45,13 +41,13 @@ jobs:
 
     steps:
       - name: Checkout
-        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        if: github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Determine prerelease version
-        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        if: github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none'
         id: prerelease-version
         env:
           RELEASE_CHANNEL: ${{ inputs.release_channel }}
@@ -475,7 +471,7 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             release_tag="v$package_version"
 
-            if [ "${{ inputs.create_release }}" = "true" ] && [ "$package_version" != "${{ needs.prepare-version.outputs.version }}" ]; then
+            if [ "${{ inputs.release_channel }}" != "none" ] && [ "$package_version" != "${{ needs.prepare-version.outputs.version }}" ]; then
               echo "Packed version $package_version does not match selected prerelease version ${{ needs.prepare-version.outputs.version }}."
               exit 1
             fi
@@ -514,7 +510,7 @@ jobs:
       - name: Log in to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && inputs.create_release && inputs.release_channel != 'alpha')
+          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
@@ -523,7 +519,7 @@ jobs:
       - name: Publish to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && inputs.create_release && inputs.release_channel != 'alpha')
+          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"
@@ -532,7 +528,7 @@ jobs:
           --skip-duplicate
 
       - name: Ensure GitHub prerelease exists
-        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        if: github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -552,7 +548,7 @@ jobs:
             --prerelease
 
       - name: Attach packages to the GitHub release
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.create_release)
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none')
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      release_channel:
+        description: Prerelease channel to use when creating a GitHub prerelease
+        type: choice
+        required: true
+        default: alpha
+        options:
+          - alpha
+          - beta
+          - rc
       create_release:
         description: Create a GitHub prerelease and attach packages
         type: boolean
@@ -23,14 +32,80 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   CONFIGURATION: Release
   ARTIFACTS_PATH: ./artifacts
-  MinVerDefaultPreReleaseIdentifiers: ${{ github.event_name == 'workflow_dispatch' && 'alpha' || 'preview' }}
+  MinVerDefaultPreReleaseIdentifiers: preview
 
 jobs:
-  validate-and-pack:
-    name: Validate and pack
+  prepare-version:
+    name: Prepare version
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.prerelease-version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine prerelease version
+        if: github.event_name == 'workflow_dispatch' && inputs.create_release
+        id: prerelease-version
+        env:
+          RELEASE_CHANNEL: ${{ inputs.release_channel }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          minimum_major_minor=$(sed -n 's:.*<MinVerMinimumMajorMinor>\([^<]*\)</MinVerMinimumMajorMinor>.*:\1:p' eng/Package.props | head -n 1)
+
+          if [[ ! "$minimum_major_minor" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not determine MinVerMinimumMajorMinor from eng/Package.props."
+            exit 1
+          fi
+
+          minimum_version="${minimum_major_minor}.0"
+          latest_stable_tag=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+
+          if [ -z "$latest_stable_tag" ]; then
+            release_base="$minimum_version"
+          else
+            latest_stable_version="${latest_stable_tag#v}"
+            IFS=. read -r stable_major stable_minor _ <<< "$latest_stable_version"
+            auto_incremented_version="${stable_major}.$((stable_minor + 1)).0"
+
+            release_base=$(printf '%s\n%s\n' "$minimum_version" "$auto_incremented_version" | sort -V | tail -n 1)
+          fi
+
+          latest_channel_tag=$(git tag -l "v${release_base}-${RELEASE_CHANNEL}.*" --sort=-version:refname | head -n 1 || true)
+
+          if [ -z "$latest_channel_tag" ]; then
+            channel_number=1
+          else
+            channel_number="${latest_channel_tag##*.}"
+
+            if [[ ! "$channel_number" =~ ^[0-9]+$ ]]; then
+              echo "Could not determine prerelease number from $latest_channel_tag."
+              exit 1
+            fi
+
+            channel_number=$((channel_number + 1))
+          fi
+
+          version="${release_base}-${RELEASE_CHANNEL}.${channel_number}"
+          echo "Selected prerelease version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  validate-and-pack:
+    name: Validate and pack
+    needs: prepare-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MinVerVersionOverride: ${{ needs.prepare-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -75,9 +150,12 @@ jobs:
 
   smoke-pack:
     name: Pack for template smoke tests
+    needs: prepare-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MinVerVersionOverride: ${{ needs.prepare-version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -317,7 +395,7 @@ jobs:
 
   publish:
     name: Publish
-    needs: [validate-and-pack, template-smoke-test]
+    needs: [prepare-version, validate-and-pack, template-smoke-test]
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release'
     runs-on: ubuntu-latest
     permissions:
@@ -396,6 +474,11 @@ jobs:
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             release_tag="v$package_version"
+
+            if [ "${{ inputs.create_release }}" = "true" ] && [ "$package_version" != "${{ needs.prepare-version.outputs.version }}" ]; then
+              echo "Packed version $package_version does not match selected prerelease version ${{ needs.prepare-version.outputs.version }}."
+              exit 1
+            fi
           else
             release_tag="${{ github.event.release.tag_name }}"
             tag_version="${release_tag#v}"
@@ -442,7 +525,7 @@ jobs:
           --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
           --skip-duplicate
 
-      - name: Ensure alpha GitHub prerelease exists
+      - name: Ensure GitHub prerelease exists
         if: github.event_name == 'workflow_dispatch' && inputs.create_release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,14 +510,18 @@ jobs:
           --skip-duplicate
 
       - name: Log in to NuGet.org
-        if: github.event_name == 'release'
+        if: >-
+          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.create_release && inputs.release_channel != 'alpha')
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: Kralizek
 
       - name: Publish to NuGet.org
-        if: github.event_name == 'release'
+        if: >-
+          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
+          (github.event_name == 'workflow_dispatch' && inputs.create_release && inputs.release_channel != 'alpha')
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
           - alpha
           - beta
           - rc
+      dry_run:
+        description: Validate the selected release without publishing packages or creating a release
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -488,7 +493,23 @@ jobs:
           echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
 
+      - name: Dry-run release summary
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        shell: bash
+        run: |
+          echo "Dry run: no packages or GitHub release will be published."
+          echo "Release channel: ${{ inputs.release_channel }}"
+          echo "Package version: $PACKAGE_VERSION"
+          if [ "${{ inputs.release_channel }}" = "alpha" ]; then
+            echo "Production release would publish to GitHub Packages and create a GitHub prerelease."
+          elif [ "${{ inputs.release_channel }}" = "beta" ] || [ "${{ inputs.release_channel }}" = "rc" ]; then
+            echo "Production release would publish to GitHub Packages and NuGet.org and create a GitHub prerelease."
+          else
+            echo "Production run would publish the package to GitHub Packages only."
+          fi
+
       - name: Configure GitHub Packages source
+        if: github.event_name == 'release' || !inputs.dry_run
         run: >-
           dotnet nuget add source
           "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
@@ -498,6 +519,7 @@ jobs:
           --store-password-in-clear-text
 
       - name: Publish to GitHub Packages
+        if: github.event_name == 'release' || !inputs.dry_run
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"
@@ -510,7 +532,7 @@ jobs:
       - name: Log in to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
@@ -519,7 +541,7 @@ jobs:
       - name: Publish to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
         run: >-
           dotnet nuget push
           "./artifacts/packages/*.nupkg"
@@ -528,7 +550,7 @@ jobs:
           --skip-duplicate
 
       - name: Ensure GitHub prerelease exists
-        if: github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none'
+        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -548,7 +570,7 @@ jobs:
             --prerelease
 
       - name: Attach packages to the GitHub release
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none')
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none')
         env:
           GH_TOKEN: ${{ github.token }}
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,7 +532,7 @@ jobs:
       - name: Log in to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && !inputs.dry_run && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
+          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
         id: nuget-login
         uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,8 @@ jobs:
           --api-key "${{ github.token }}"
           --skip-duplicate
 
+      # Alpha releases stay on GitHub for explicit/manual consumption.
+      # Beta, RC, and stable releases are also published to NuGet.org.
       - name: Log in to NuGet.org
         if: >-
           (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||


### PR DESCRIPTION
## Summary

- use a single `release_channel` workflow-dispatch input with `none`, `alpha`, `beta`, or `rc`
- add a `dry_run` flag, default `false`, to exercise prerelease versioning and the full validation/package/smoke pipeline without external publishing side effects
- treat `none` as a manual package build with normal MinVer-derived versioning and no GitHub release
- calculate the next channel number from existing tags for explicit alpha, beta, and RC releases
- pass the selected prerelease version to MinVer through `MinVerVersionOverride` so all packed projects share the exact release version
- keep alpha releases GitHub-only for explicit/manual consumption
- publish beta, RC, and stable releases to NuGet.org through trusted publishing
- preserve tag-driven versioning for GitHub release events and stable releases

## Expected behavior

With `v6.0.0-alpha.13` already present:

- manual dispatch + `none` builds and publishes the normal MinVer-derived package version to GitHub Packages only
- manual dispatch + `alpha` produces `6.0.0-alpha.14`, publishes to GitHub Packages, and creates a GitHub prerelease, but does not publish to NuGet.org
- manual dispatch + `beta` produces `6.0.0-beta.1` and publishes to GitHub Packages, GitHub Releases, and NuGet.org
- manual dispatch + `rc` produces `6.0.0-rc.1` and publishes to GitHub Packages, GitHub Releases, and NuGet.org
- setting `dry_run: true` still calculates and validates the selected version, builds and packs all packages, runs template smoke tests, and validates release metadata
- beta/RC dry runs also execute the NuGet trusted-publishing login so the OIDC configuration is exercised, but skip the actual NuGet push
- dry runs skip GitHub Packages publishing, GitHub release creation, and release asset upload; alpha dry runs do not touch NuGet.org at all
- stable releases continue to publish to GitHub Packages and NuGet.org
- once `v6.0.0` exists, the next prerelease line follows the configured MinVer minor auto-increment and starts from `6.1.0-<channel>.N`

The release workflow validates that the packed version and release tag agree before publishing. Alpha-tagged GitHub release events are also excluded from NuGet.org publishing.