### PR TITLE
Add OpenTelemetry function samples

### DIFF
--- a/AWSLambdaSharpTemplate.slnx
+++ b/AWSLambdaSharpTemplate.slnx
@@ -5,7 +5,9 @@
     <Project Path="samples/EventBridgeFunction/EventBridgeFunction.csproj" />
     <Project Path="samples/EventFunction/EventFunction.csproj" />
     <Project Path="samples/KinesisStreamFunction/KinesisStreamFunction.csproj" />
+    <Project Path="samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj" />
     <Project Path="samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj" />
+    <Project Path="samples/OpenTelemetrySqsFunction/OpenTelemetrySqsFunction.csproj" />
     <Project Path="samples/RawSnsFunction/RawSnsFunction.csproj" />
     <Project Path="samples/RawSqsFunction/RawSqsFunction.csproj" />
     <Project Path="samples/RequestFunction/RequestFunction.csproj" />

--- a/AWSLambdaSharpTemplate.slnx
+++ b/AWSLambdaSharpTemplate.slnx
@@ -5,6 +5,7 @@
     <Project Path="samples/EventBridgeFunction/EventBridgeFunction.csproj" />
     <Project Path="samples/EventFunction/EventFunction.csproj" />
     <Project Path="samples/KinesisStreamFunction/KinesisStreamFunction.csproj" />
+    <Project Path="samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj" />
     <Project Path="samples/RawSnsFunction/RawSnsFunction.csproj" />
     <Project Path="samples/RawSqsFunction/RawSqsFunction.csproj" />
     <Project Path="samples/RequestFunction/RequestFunction.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,5 +26,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.17.0" />
   </ItemGroup>
 </Project>

--- a/samples/OpenTelemetryEventFunction/Function.cs
+++ b/samples/OpenTelemetryEventFunction/Function.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Logging;
+
+using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Trace;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace OpenTelemetryEventFunction;
+
+public class Function : EventFunction<string, StringEventHandler>
+{
+    private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
+        .AddConsoleExporter()
+        .Build();
+
+    public new Task FunctionHandlerAsync(string input, ILambdaContext context) =>
+        AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);
+}
+
+public class StringEventHandler(ILogger<StringEventHandler> logger) : IEventHandler<string>
+{
+    public ValueTask HandleAsync(string input, EventContext context, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Input {Input} for request {AwsRequestId}", input, context.AwsRequestId);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj
+++ b/samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OpenTelemetryEventFunction/README.md
+++ b/samples/OpenTelemetryEventFunction/README.md
@@ -1,0 +1,21 @@
+# OpenTelemetry event function
+
+This sample shows how to instrument a function built with `EventFunction` using the standard `OpenTelemetry.Instrumentation.AWSLambda` package.
+
+The concrete function hides the inherited `FunctionHandlerAsync` method with the same Lambda-compatible signature and delegates to `AWSLambdaWrapper.TraceAsync`, passing the inherited handler as the wrapped delegate. The normal `EventFunction` lifecycle remains unchanged underneath the wrapper.
+
+`AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
+
+The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+
+Deploy the sample from this directory with:
+
+```shell
+dotnet lambda deploy-function
+```
+
+Then invoke it with:
+
+```shell
+dotnet lambda invoke-function otel-event-function --payload "Hello World"
+```

--- a/samples/OpenTelemetryEventFunction/README.md
+++ b/samples/OpenTelemetryEventFunction/README.md
@@ -8,6 +8,8 @@ The concrete function hides the inherited `FunctionHandlerAsync` method with the
 
 The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
 
+Equivalent samples are also available for `RequestFunction` in `../OpenTelemetryRequestFunction` and for record processing with typed SQS in `../OpenTelemetrySqsFunction`.
+
 Deploy the sample from this directory with:
 
 ```shell

--- a/samples/OpenTelemetryEventFunction/aws-lambda-tools-defaults.json
+++ b/samples/OpenTelemetryEventFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "otel-event-function",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "OpenTelemetryEventFunction::OpenTelemetryEventFunction.Function::FunctionHandlerAsync"
+}

--- a/samples/OpenTelemetryRequestFunction/Function.cs
+++ b/samples/OpenTelemetryRequestFunction/Function.cs
@@ -18,7 +18,7 @@ namespace OpenTelemetryRequestFunction;
 public class Function : RequestFunction<string, string, UpperCaseHandler>
 {
     private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
-        .AddAWSLambdaConfigurations()
+        .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
         .AddConsoleExporter()
         .Build();
 

--- a/samples/OpenTelemetryRequestFunction/Function.cs
+++ b/samples/OpenTelemetryRequestFunction/Function.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Logging;
+
+using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Trace;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace OpenTelemetryRequestFunction;
+
+public class Function : RequestFunction<string, string, UpperCaseHandler>
+{
+    private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAWSLambdaConfigurations()
+        .AddConsoleExporter()
+        .Build();
+
+    public new Task<string> FunctionHandlerAsync(string input, ILambdaContext context) =>
+        AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);
+}
+
+public class UpperCaseHandler : IRequestHandler<string, string>
+{
+    private readonly ILogger<UpperCaseHandler> _logger;
+
+    public UpperCaseHandler(ILogger<UpperCaseHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public ValueTask<string> HandleAsync(string input, RequestContext context, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Input {Input} for request {AwsRequestId}", input, context.AwsRequestId);
+        return new ValueTask<string>(input.ToUpperInvariant());
+    }
+}

--- a/samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj
+++ b/samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OpenTelemetryRequestFunction/README.md
+++ b/samples/OpenTelemetryRequestFunction/README.md
@@ -1,9 +1,23 @@
-# OpenTelemetry request-function experiment
+# OpenTelemetry request function
 
-This sample explores whether the standard OpenTelemetry AWS Lambda instrumentation can wrap a function built with `RequestFunction` without changing the framework.
+This sample shows how to instrument a function built with `RequestFunction` using the standard `OpenTelemetry.Instrumentation.AWSLambda` package.
 
-The function accepts a string and returns its upper-case representation. The inherited `FunctionHandlerAsync` method is hidden with a method that has the same Lambda handler signature. That method delegates to `AWSLambdaWrapper.TraceAsync`, passing the inherited handler as the wrapped delegate.
+The function accepts a string and returns its upper-case representation. The concrete function hides the inherited `FunctionHandlerAsync` method with a method that has the same Lambda-compatible signature and delegates to `AWSLambdaWrapper.TraceAsync`, passing the inherited handler as the wrapped delegate.
 
-The sample deliberately uses the console exporter so the experiment has no external collector dependency. It is not intended as production OpenTelemetry configuration.
+`AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
 
-The experiment is successful if the project builds, Lambda resolves the derived `FunctionHandlerAsync` as the configured handler, the request still flows through the existing framework lifecycle, and the standard AWS Lambda instrumentation emits the invocation span.
+The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+
+Deploy the sample from this directory with:
+
+```shell
+dotnet lambda deploy-function
+```
+
+Then invoke it with:
+
+```shell
+dotnet lambda invoke-function otel-request-function --payload "Hello World"
+```
+
+The invocation returns `"HELLO WORLD"` and the Lambda logs include the server span emitted by the standard AWS Lambda OpenTelemetry instrumentation.

--- a/samples/OpenTelemetryRequestFunction/README.md
+++ b/samples/OpenTelemetryRequestFunction/README.md
@@ -8,6 +8,8 @@ The function accepts a string and returns its upper-case representation. The con
 
 The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
 
+Equivalent samples are also available for `EventFunction` in `../OpenTelemetryEventFunction` and for record processing with typed SQS in `../OpenTelemetrySqsFunction`.
+
 Deploy the sample from this directory with:
 
 ```shell

--- a/samples/OpenTelemetryRequestFunction/README.md
+++ b/samples/OpenTelemetryRequestFunction/README.md
@@ -1,0 +1,9 @@
+# OpenTelemetry request-function experiment
+
+This sample explores whether the standard OpenTelemetry AWS Lambda instrumentation can wrap a function built with `RequestFunction` without changing the framework.
+
+The function accepts a string and returns its upper-case representation. The inherited `FunctionHandlerAsync` method is hidden with a method that has the same Lambda handler signature. That method delegates to `AWSLambdaWrapper.TraceAsync`, passing the inherited handler as the wrapped delegate.
+
+The sample deliberately uses the console exporter so the experiment has no external collector dependency. It is not intended as production OpenTelemetry configuration.
+
+The experiment is successful if the project builds, Lambda resolves the derived `FunctionHandlerAsync` as the configured handler, the request still flows through the existing framework lifecycle, and the standard AWS Lambda instrumentation emits the invocation span.

--- a/samples/OpenTelemetryRequestFunction/README.md
+++ b/samples/OpenTelemetryRequestFunction/README.md
@@ -21,3 +21,5 @@ dotnet lambda invoke-function otel-request-function --payload "Hello World"
 ```
 
 The invocation returns `"HELLO WORLD"` and the Lambda logs include the server span emitted by the standard AWS Lambda OpenTelemetry instrumentation.
+
+The wrapper pattern in this sample has also been validated against the AWS Lambda .NET 10 runtime: Lambda resolves the derived handler, the request continues through the normal `RequestFunction` lifecycle, and the standard AWS Lambda instrumentation exports the invocation span.

--- a/samples/OpenTelemetryRequestFunction/aws-lambda-tools-defaults.json
+++ b/samples/OpenTelemetryRequestFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "otel-request-function-experiment",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "OpenTelemetryRequestFunction::OpenTelemetryRequestFunction.Function::FunctionHandlerAsync"
+}

--- a/samples/OpenTelemetryRequestFunction/aws-lambda-tools-defaults.json
+++ b/samples/OpenTelemetryRequestFunction/aws-lambda-tools-defaults.json
@@ -13,7 +13,7 @@
   "configuration": "Release",
   "framework": "net10.0",
   "function-runtime": "dotnet10",
-  "function-name": "otel-request-function-experiment",
+  "function-name": "otel-request-function",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "OpenTelemetryRequestFunction::OpenTelemetryRequestFunction.Function::FunctionHandlerAsync"

--- a/samples/OpenTelemetrySqsFunction/Function.cs
+++ b/samples/OpenTelemetrySqsFunction/Function.cs
@@ -1,0 +1,47 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Logging;
+
+using OpenTelemetry;
+using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Trace;
+
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace OpenTelemetrySqsFunction;
+
+public class Function : SqsFunction<OrderCreated, OrderCreatedHandler>
+{
+    private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
+        .AddConsoleExporter()
+        .Build();
+
+    public new Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context) =>
+        AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);
+}
+
+public sealed record OrderCreated(string OrderId);
+
+public sealed class OrderCreatedHandler(ILogger<OrderCreatedHandler> logger)
+    : ISqsMessageHandler<OrderCreated>
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        OrderCreated message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "Processing order {OrderId} from SQS message {MessageId}",
+            message.OrderId,
+            context.MessageId);
+
+        return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}

--- a/samples/OpenTelemetrySqsFunction/OpenTelemetrySqsFunction.csproj
+++ b/samples/OpenTelemetrySqsFunction/OpenTelemetrySqsFunction.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.Sqs\Kralizek.Lambda.Template.Sqs.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
+  </ItemGroup>
+
+</Project>

--- a/samples/OpenTelemetrySqsFunction/README.md
+++ b/samples/OpenTelemetrySqsFunction/README.md
@@ -1,0 +1,21 @@
+# OpenTelemetry SQS function
+
+This sample shows how to instrument a typed SQS function using the standard `OpenTelemetry.Instrumentation.AWSLambda` package.
+
+The concrete function hides the inherited `FunctionHandlerAsync` method with the same Lambda-compatible `SQSEvent`/`SQSBatchResponse` signature and delegates to `AWSLambdaWrapper.TraceAsync`, passing the inherited handler as the wrapped delegate. The normal SQS record-processing and partial-batch-response behavior remains unchanged underneath the wrapper.
+
+`AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
+
+The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+
+Deploy the sample from this directory with:
+
+```shell
+dotnet lambda deploy-function
+```
+
+To exercise the function in AWS, configure an SQS event source mapping for the deployed function and send messages whose body matches the sample payload:
+
+```json
+{"OrderId":"order-123"}
+```

--- a/samples/OpenTelemetrySqsFunction/README.md
+++ b/samples/OpenTelemetrySqsFunction/README.md
@@ -8,6 +8,8 @@ The concrete function hides the inherited `FunctionHandlerAsync` method with the
 
 The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
 
+Equivalent samples are also available for `RequestFunction` in `../OpenTelemetryRequestFunction` and for `EventFunction` in `../OpenTelemetryEventFunction`.
+
 Deploy the sample from this directory with:
 
 ```shell

--- a/samples/OpenTelemetrySqsFunction/aws-lambda-tools-defaults.json
+++ b/samples/OpenTelemetrySqsFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "otel-sqs-function",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "OpenTelemetrySqsFunction::OpenTelemetrySqsFunction.Function::FunctionHandlerAsync"
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -10,6 +10,9 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | --- | --- | --- |
 | A Lambda that consumes an event and returns no application response | [EventFunction](EventFunction/) | `EventFunction<TInput, THandler>`, handler DI, logging, and `EventContext` |
 | A Lambda with a typed request and response | [RequestFunction](RequestFunction/) | `RequestFunction<TInput, TOutput, THandler>` and `RequestContext` |
+| OpenTelemetry instrumentation for a request/response Lambda | [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/) | wrapping the inherited request handler with `AWSLambdaWrapper.TraceAsync` and exporting the invocation span |
+| OpenTelemetry instrumentation for an event Lambda | [OpenTelemetryEventFunction](OpenTelemetryEventFunction/) | the same standard AWS Lambda OpenTelemetry wrapper pattern applied to `EventFunction` |
+| OpenTelemetry instrumentation for SQS record processing | [OpenTelemetrySqsFunction](OpenTelemetrySqsFunction/) | wrapping a typed SQS record function while preserving `SQSBatchResponse` and partial batch failures |
 | JSON messages from SQS | [SqsFunction](SqsFunction/) | typed payload decoding, `IRecordProcessor`-backed per-record scopes, and partial batch failures |
 | SQS messages without decoding the body | [RawSqsFunction](RawSqsFunction/) | raw record handling when the AWS envelope is the application contract |
 | S3 notifications delivered through SNS → SQS with raw message delivery | [SqsRawSnsS3Function](SqsRawSnsS3Function/) | nested S3 record composition when the SQS body is the `S3Event` directly |
@@ -26,6 +29,10 @@ Each sample README shows the expected Lambda input shape and how that input maps
 ### Generic event vs request/response
 
 Start with [EventFunction](EventFunction/) if the caller does not consume an application response. Use [RequestFunction](RequestFunction/) when the Lambda invocation is explicitly request/response and your handler returns a value.
+
+### OpenTelemetry across function shapes
+
+Compare [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/), [OpenTelemetryEventFunction](OpenTelemetryEventFunction/), and [OpenTelemetrySqsFunction](OpenTelemetrySqsFunction/). All three use the standard `OpenTelemetry.Instrumentation.AWSLambda` wrapper around the inherited `FunctionHandlerAsync`; only the Lambda handler signature changes. The framework lifecycle remains unchanged underneath the wrapper, including SQS partial-batch-response behavior.
 
 ### Decoded vs raw messages
 


### PR DESCRIPTION
## What changed

- added OpenTelemetry samples for all three framework shapes:
  - `RequestFunction`
  - `EventFunction`
  - typed SQS record processing
- wrapped each inherited `FunctionHandlerAsync` with `AWSLambdaWrapper.TraceAsync`
- configured `AddAWSLambdaConfigurations` and disabled AWS X-Ray context extraction so tracing works when X-Ray is not enabled
- kept the console exporter to make the samples self-contained and observable in Lambda logs
- added deployment defaults and usage documentation for each sample

## Why

The framework remains compatible with the standard AWS Lambda OpenTelemetry instrumentation model across request, event, and record-based functions. Consumers can instrument their functions without changing the framework or introducing a framework-specific tracing abstraction.

Each concrete function exposes the normal Lambda-compatible handler signature and delegates to `AWSLambdaWrapper.TraceAsync`, which invokes the inherited framework handler. This preserves the existing framework lifecycle while letting the standard instrumentation own the Lambda invocation span.

The SQS sample also demonstrates that the same pattern works with a record function returning `SQSBatchResponse`, preserving partial-batch-response behavior underneath the wrapper.

## Impact

This is a sample-only change. No production library or template behavior changes.

The console exporter is intentionally used only to keep the samples standalone. Applications can replace it with OTLP or another OpenTelemetry exporter without changing the wrapper pattern.

## Validation

The request-function variant has been validated against the AWS Lambda .NET 10 runtime. Lambda resolved the derived `FunctionHandlerAsync`, the request flowed through the existing framework lifecycle, and the standard AWS Lambda instrumentation exported a recorded server span with the expected Lambda/FaaS attributes.

CI will validate the additional event and SQS variants compile against the same wrapper pattern.