### PR TITLE
Add Lambda deployment defaults to remaining samples

### DIFF
--- a/samples/SqsRawSnsS3Function/aws-lambda-tools-defaults.json
+++ b/samples/SqsRawSnsS3Function/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "sqs-raw-sns-s3-function-sample",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "SqsRawSnsS3Function::SqsRawSnsS3Function.Function::FunctionHandlerAsync"
+}

--- a/samples/SqsSnsS3Function/aws-lambda-tools-defaults.json
+++ b/samples/SqsSnsS3Function/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "sqs-sns-s3-function-sample",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "SqsSnsS3Function::SqsSnsS3Function.Function::FunctionHandlerAsync"
+}


### PR DESCRIPTION
## What changed

- added `aws-lambda-tools-defaults.json` to `SqsRawSnsS3Function`
- added `aws-lambda-tools-defaults.json` to `SqsSnsS3Function`
- aligned both files with the existing sample deployment defaults: .NET 10 runtime, eu-west-1, 256 MB memory, 30 second timeout, and the correct `FunctionHandlerAsync` entry point

## Why

Most samples already include deployment defaults, but the two nested-envelope samples did not. Adding the missing files makes all samples directly deployable with the standard `dotnet lambda deploy-function` workflow.

## Impact

Sample-only change. No library or template behavior changes.

## Validation

The handler values were derived from the concrete sample function classes. Repository CI will validate the branch.