### PR TITLE
Add Aspire AppHost sample

### DIFF
--- a/AWSLambdaSharpTemplate.slnx
+++ b/AWSLambdaSharpTemplate.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/samples/">
+    <Project Path="samples/AppHost/AppHost.csproj" />
     <Project Path="samples/CognitoPreSignUpFunction/CognitoPreSignUpFunction.csproj" />
     <Project Path="samples/DynamoDbStreamFunction/DynamoDbStreamFunction.csproj" />
     <Project Path="samples/EventBridgeFunction/EventBridgeFunction.csproj" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.AWS" Version="13.6.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.17.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.AWS" Version="13.6.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.AWS" Version="13.6.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);ASPIRE004</NoWarn>
   </PropertyGroup>
 

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.AWS" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" />
+    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -5,13 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.AWS" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EventFunction\EventFunction.csproj" />
-    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" />
-    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" />
+    <ProjectReference Include="..\EventFunction\EventFunction.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
 
 </Project>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);ASPIRE004</NoWarn>
   </PropertyGroup>
 

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <NoWarn>$(NoWarn);ASPIRE004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.AWS" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EventFunction\EventFunction.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\EventFunction\EventFunction.csproj" />
+    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" />
+    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EventFunction\EventFunction.csproj" />
     <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" />
     <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" />
   </ItemGroup>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EventFunction\EventFunction.csproj" />
-    <ProjectReference Include="..\RequestFunction\RequestFunction.csproj" />
-    <ProjectReference Include="..\SqsFunction\SqsFunction.csproj" />
+    <ProjectReference Include="..\OpenTelemetryEventFunction\OpenTelemetryEventFunction.csproj" />
+    <ProjectReference Include="..\OpenTelemetryRequestFunction\OpenTelemetryRequestFunction.csproj" />
+    <ProjectReference Include="..\OpenTelemetrySqsFunction\OpenTelemetrySqsFunction.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -1,12 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.AWS" />
   </ItemGroup>
 

--- a/samples/AppHost/Program.cs
+++ b/samples/AppHost/Program.cs
@@ -9,16 +9,19 @@ var aws = builder.AddAWSSDKConfig()
 builder.AddAWSLambdaFunction<Projects.OpenTelemetryEventFunction>(
         "event-function",
         "OpenTelemetryEventFunction::OpenTelemetryEventFunction.Function::FunctionHandlerAsync")
-    .WithReference(aws);
+    .WithReference(aws)
+    .WithOtlpExporter();
 
 builder.AddAWSLambdaFunction<Projects.OpenTelemetryRequestFunction>(
         "request-function",
         "OpenTelemetryRequestFunction::OpenTelemetryRequestFunction.Function::FunctionHandlerAsync")
-    .WithReference(aws);
+    .WithReference(aws)
+    .WithOtlpExporter();
 
 builder.AddAWSLambdaFunction<Projects.OpenTelemetrySqsFunction>(
         "sqs-function",
         "OpenTelemetrySqsFunction::OpenTelemetrySqsFunction.Function::FunctionHandlerAsync")
-    .WithReference(aws);
+    .WithReference(aws)
+    .WithOtlpExporter();
 
 builder.Build().Run();

--- a/samples/AppHost/Program.cs
+++ b/samples/AppHost/Program.cs
@@ -6,19 +6,19 @@ var aws = builder.AddAWSSDKConfig()
     .WithProfile("default")
     .WithRegion(RegionEndpoint.EUWest1);
 
-builder.AddAWSLambdaFunction<Projects.EventFunction>(
+builder.AddAWSLambdaFunction<Projects.OpenTelemetryEventFunction>(
         "event-function",
-        "EventFunction::EventFunction.Function::FunctionHandlerAsync")
+        "OpenTelemetryEventFunction::OpenTelemetryEventFunction.Function::FunctionHandlerAsync")
     .WithReference(aws);
 
-builder.AddAWSLambdaFunction<Projects.RequestFunction>(
+builder.AddAWSLambdaFunction<Projects.OpenTelemetryRequestFunction>(
         "request-function",
-        "RequestFunction::RequestFunction.Function::FunctionHandlerAsync")
+        "OpenTelemetryRequestFunction::OpenTelemetryRequestFunction.Function::FunctionHandlerAsync")
     .WithReference(aws);
 
-builder.AddAWSLambdaFunction<Projects.SqsFunction>(
+builder.AddAWSLambdaFunction<Projects.OpenTelemetrySqsFunction>(
         "sqs-function",
-        "SqsFunction::SqsFunction.Function::FunctionHandlerAsync")
+        "OpenTelemetrySqsFunction::OpenTelemetrySqsFunction.Function::FunctionHandlerAsync")
     .WithReference(aws);
 
 builder.Build().Run();

--- a/samples/AppHost/Program.cs
+++ b/samples/AppHost/Program.cs
@@ -1,0 +1,19 @@
+using Amazon;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var aws = builder.AddAWSSDKConfig()
+    .WithProfile("default")
+    .WithRegion(RegionEndpoint.EUWest1);
+
+builder.AddAWSLambdaFunction<Projects.RequestFunction>(
+        "request-function",
+        "RequestFunction::RequestFunction.Function::FunctionHandlerAsync")
+    .WithReference(aws);
+
+builder.AddAWSLambdaFunction<Projects.SqsFunction>(
+        "sqs-function",
+        "SqsFunction::SqsFunction.Function::FunctionHandlerAsync")
+    .WithReference(aws);
+
+builder.Build().Run();

--- a/samples/AppHost/Program.cs
+++ b/samples/AppHost/Program.cs
@@ -6,6 +6,11 @@ var aws = builder.AddAWSSDKConfig()
     .WithProfile("default")
     .WithRegion(RegionEndpoint.EUWest1);
 
+builder.AddAWSLambdaFunction<Projects.EventFunction>(
+        "event-function",
+        "EventFunction::EventFunction.Function::FunctionHandlerAsync")
+    .WithReference(aws);
+
 builder.AddAWSLambdaFunction<Projects.RequestFunction>(
         "request-function",
         "RequestFunction::RequestFunction.Function::FunctionHandlerAsync")

--- a/samples/AppHost/README.md
+++ b/samples/AppHost/README.md
@@ -1,0 +1,22 @@
+# Aspire AppHost sample
+
+This sample shows how existing Lambda function projects in this repository can be composed in a .NET Aspire AppHost without restructuring them into a nested solution.
+
+The AppHost references two existing standalone samples:
+
+- `RequestFunction`, representing a request/response function;
+- `SqsFunction`, representing record-oriented batch processing.
+
+Both functions are registered with the AWS Aspire integration and run locally through the AWS Lambda test tool managed by `Aspire.Hosting.AWS`.
+
+## Run
+
+Configure the `default` AWS profile, then run:
+
+```bash
+dotnet run --project samples/AppHost/AppHost.csproj
+```
+
+The AppHost uses `eu-west-1` by default. Change the profile or region in `Program.cs` if needed.
+
+The Lambda projects remain independently runnable samples. The AppHost only demonstrates composing them for local development and orchestration.

--- a/samples/AppHost/README.md
+++ b/samples/AppHost/README.md
@@ -10,6 +10,8 @@ The AppHost references three existing standalone samples:
 
 All three functions are registered with the AWS Aspire integration and run locally through the AWS Lambda test tool managed by `Aspire.Hosting.AWS`.
 
+Each function exports OpenTelemetry traces and logs through OTLP. The AppHost enables Aspire OTLP configuration for the Lambda resources, so the Aspire dashboard receives those signals and can display both invocation traces and application logs while the functions run locally.
+
 ## Run
 
 Configure the `default` AWS profile, then run:
@@ -20,4 +22,4 @@ dotnet run --project samples/AppHost/AppHost.csproj
 
 The AppHost uses `eu-west-1` by default. Change the profile or region in `Program.cs` if needed.
 
-The Lambda projects remain independently runnable samples. The AppHost only demonstrates composing them for local development and orchestration.
+The Lambda projects remain independently runnable samples. The AppHost only demonstrates composing them for local development, orchestration, and local observability through Aspire.

--- a/samples/AppHost/README.md
+++ b/samples/AppHost/README.md
@@ -2,12 +2,13 @@
 
 This sample shows how existing Lambda function projects in this repository can be composed in a .NET Aspire AppHost without restructuring them into a nested solution.
 
-The AppHost references two existing standalone samples:
+The AppHost references three existing standalone samples:
 
+- `EventFunction`, representing a one-way event function;
 - `RequestFunction`, representing a request/response function;
 - `SqsFunction`, representing record-oriented batch processing.
 
-Both functions are registered with the AWS Aspire integration and run locally through the AWS Lambda test tool managed by `Aspire.Hosting.AWS`.
+All three functions are registered with the AWS Aspire integration and run locally through the AWS Lambda test tool managed by `Aspire.Hosting.AWS`.
 
 ## Run
 

--- a/samples/AppHost/README.md
+++ b/samples/AppHost/README.md
@@ -1,12 +1,12 @@
 # Aspire AppHost sample
 
-This sample shows how existing Lambda function projects in this repository can be composed in a .NET Aspire AppHost without restructuring them into a nested solution.
+This sample shows how existing OpenTelemetry-enabled Lambda function projects in this repository can be composed in a .NET Aspire AppHost without restructuring them into a nested solution.
 
 The AppHost references three existing standalone samples:
 
-- `EventFunction`, representing a one-way event function;
-- `RequestFunction`, representing a request/response function;
-- `SqsFunction`, representing record-oriented batch processing.
+- `OpenTelemetryEventFunction`, representing a one-way event function;
+- `OpenTelemetryRequestFunction`, representing a request/response function;
+- `OpenTelemetrySqsFunction`, representing record-oriented batch processing.
 
 All three functions are registered with the AWS Aspire integration and run locally through the AWS Lambda test tool managed by `Aspire.Hosting.AWS`.
 

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,6 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/samples/OpenTelemetryEventFunction/Function.cs
+++ b/samples/OpenTelemetryEventFunction/Function.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -20,7 +21,11 @@ public class Function : EventFunction<string, StringEventHandler>
     private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
         .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
         .AddConsoleExporter()
+        .AddOtlpExporter()
         .Build();
+
+    protected override void ConfigureLogging(ILoggingBuilder logging) =>
+        logging.AddOpenTelemetry(options => options.AddOtlpExporter());
 
     public new Task FunctionHandlerAsync(string input, ILambdaContext context) =>
         AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);

--- a/samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj
+++ b/samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
   </ItemGroup>
 

--- a/samples/OpenTelemetryEventFunction/README.md
+++ b/samples/OpenTelemetryEventFunction/README.md
@@ -6,7 +6,9 @@ The concrete function hides the inherited `FunctionHandlerAsync` method with the
 
 `AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
 
-The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+The sample exports traces to both the console and OTLP. It also adds an OpenTelemetry logging provider that exports `ILogger` records through OTLP. The OTLP exporter follows the standard OpenTelemetry environment variables, so the destination can be supplied by the hosting environment without changing the function code.
+
+When this sample is run through `../AppHost`, Aspire provides the OTLP endpoint and related OpenTelemetry environment variables. Invocation traces and application logs are then available in the Aspire dashboard.
 
 Equivalent samples are also available for `RequestFunction` in `../OpenTelemetryRequestFunction` and for record processing with typed SQS in `../OpenTelemetrySqsFunction`.
 

--- a/samples/OpenTelemetryRequestFunction/Function.cs
+++ b/samples/OpenTelemetryRequestFunction/Function.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -20,7 +21,11 @@ public class Function : RequestFunction<string, string, UpperCaseHandler>
     private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
         .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
         .AddConsoleExporter()
+        .AddOtlpExporter()
         .Build();
+
+    protected override void ConfigureLogging(ILoggingBuilder logging) =>
+        logging.AddOpenTelemetry(options => options.AddOtlpExporter());
 
     public new Task<string> FunctionHandlerAsync(string input, ILambdaContext context) =>
         AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);

--- a/samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj
+++ b/samples/OpenTelemetryRequestFunction/OpenTelemetryRequestFunction.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
   </ItemGroup>
 

--- a/samples/OpenTelemetryRequestFunction/README.md
+++ b/samples/OpenTelemetryRequestFunction/README.md
@@ -6,7 +6,9 @@ The function accepts a string and returns its upper-case representation. The con
 
 `AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
 
-The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+The sample exports traces to both the console and OTLP. It also adds an OpenTelemetry logging provider that exports `ILogger` records through OTLP. The OTLP exporter follows the standard OpenTelemetry environment variables, so the destination can be supplied by the hosting environment without changing the function code.
+
+When this sample is run through `../AppHost`, Aspire provides the OTLP endpoint and related OpenTelemetry environment variables. Invocation traces and application logs are then available in the Aspire dashboard.
 
 Equivalent samples are also available for `EventFunction` in `../OpenTelemetryEventFunction` and for record processing with typed SQS in `../OpenTelemetrySqsFunction`.
 

--- a/samples/OpenTelemetrySqsFunction/Function.cs
+++ b/samples/OpenTelemetrySqsFunction/Function.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -21,7 +22,11 @@ public class Function : SqsFunction<OrderCreated, OrderCreatedHandler>
     private static readonly TracerProvider TracerProvider = Sdk.CreateTracerProviderBuilder()
         .AddAWSLambdaConfigurations(options => options.DisableAwsXRayContextExtraction = true)
         .AddConsoleExporter()
+        .AddOtlpExporter()
         .Build();
+
+    protected override void ConfigureLogging(ILoggingBuilder logging) =>
+        logging.AddOpenTelemetry(options => options.AddOtlpExporter());
 
     public new Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context) =>
         AWSLambdaWrapper.TraceAsync(TracerProvider, base.FunctionHandlerAsync, input, context);

--- a/samples/OpenTelemetrySqsFunction/OpenTelemetrySqsFunction.csproj
+++ b/samples/OpenTelemetrySqsFunction/OpenTelemetrySqsFunction.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AWSLambda" />
   </ItemGroup>
 

--- a/samples/OpenTelemetrySqsFunction/README.md
+++ b/samples/OpenTelemetrySqsFunction/README.md
@@ -6,7 +6,9 @@ The concrete function hides the inherited `FunctionHandlerAsync` method with the
 
 `AddAWSLambdaConfigurations` configures the OpenTelemetry provider for the Lambda execution environment. This sample disables AWS X-Ray context extraction so tracing also works when X-Ray is not enabled for the function. If your function uses X-Ray propagation, configure the instrumentation accordingly.
 
-The console exporter keeps the sample self-contained and makes the invocation span visible in the Lambda logs. Applications can replace it with an OTLP or other OpenTelemetry exporter without changing the wrapper pattern.
+The sample exports traces to both the console and OTLP. It also adds an OpenTelemetry logging provider that exports `ILogger` records through OTLP. The OTLP exporter follows the standard OpenTelemetry environment variables, so the destination can be supplied by the hosting environment without changing the function code.
+
+When this sample is run through `../AppHost`, Aspire provides the OTLP endpoint and related OpenTelemetry environment variables. Invocation traces and application logs are then available in the Aspire dashboard.
 
 Equivalent samples are also available for `RequestFunction` in `../OpenTelemetryRequestFunction` and for `EventFunction` in `../OpenTelemetryEventFunction`.
 


### PR DESCRIPTION
## Summary

Adds an Aspire AppHost sample without restructuring the existing standalone Lambda samples.

- adds `samples/AppHost` as a normal project in the existing solution
- references the existing OpenTelemetry-enabled `OpenTelemetryEventFunction`, `OpenTelemetryRequestFunction`, and `OpenTelemetrySqsFunction` samples
- registers all three functions with the AWS Aspire Lambda integration for local development
- demonstrates one-way event, request/response, and record-oriented function models with OpenTelemetry instrumentation
- keeps the Lambda projects independently runnable
- uses the current Aspire 13 AppHost SDK project model
- pins the latest `Aspire.Hosting.AWS` integration through central package management
- documents how to run the AppHost and change the AWS profile/region

## Versions

- `Aspire.AppHost.Sdk` 13.4.6
- `Aspire.Hosting.AWS` 13.6.0

`Aspire.Hosting.AWS` 13.6.0 requires Aspire.Hosting 13.4.6 or newer, so these versions are compatible while using the newest available AWS integration.