### PR TITLE
Simplify SNS-enveloped S3 sample orchestration

### DIFF
--- a/samples/NativeAotSqsSnsS3Function/Function.cs
+++ b/samples/NativeAotSqsSnsS3Function/Function.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.S3Events;
-using Amazon.Lambda.SQSEvents;
 
 using Kralizek.Lambda;
 
@@ -16,13 +15,14 @@ using Microsoft.Extensions.Logging;
 
 namespace NativeAotSqsSnsS3Function;
 
-public sealed class Function : SqsFunction<SqsSnsS3Handler>
+public sealed class Function : SqsFunction<SnsEnvelope, SqsSnsS3Handler>
 {
+    protected override void ConfigureFrameworkServices(IServiceCollection services) =>
+        services.AddSingleton(PayloadJsonSerializerContext.Default.SnsEnvelope);
+
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-        services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>>(
-            new JsonStringPayloadDecoder<SnsEnvelope>(PayloadJsonSerializerContext.Default.SnsEnvelope));
         services.TryAddSingleton<IStringPayloadDecoder<S3Event>>(
             new JsonStringPayloadDecoder<S3Event>(PayloadJsonSerializerContext.Default.S3Event));
     }
@@ -33,9 +33,8 @@ public sealed record SnsEnvelope
     public string Message { get; init; } = string.Empty;
 }
 
-public sealed class SqsSnsS3Handler : ISqsRecordHandler
+public sealed class SqsSnsS3Handler : ISqsMessageHandler<SnsEnvelope>
 {
-    private readonly IStringPayloadDecoder<SnsEnvelope> _snsDecoder;
     private readonly IStringPayloadDecoder<S3Event> _s3Decoder;
     private readonly IRecordProcessor<
         S3Event.S3EventNotificationRecord,
@@ -43,26 +42,23 @@ public sealed class SqsSnsS3Handler : ISqsRecordHandler
         RecordContext> _s3Processor;
 
     public SqsSnsS3Handler(
-        IStringPayloadDecoder<SnsEnvelope> snsDecoder,
         IStringPayloadDecoder<S3Event> s3Decoder,
         IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> s3Processor)
     {
-        _snsDecoder = snsDecoder;
         _s3Decoder = s3Decoder;
         _s3Processor = s3Processor;
     }
 
     public async ValueTask<SqsRecordResult> HandleAsync(
-        SQSEvent.SQSMessage record,
+        SnsEnvelope message,
         SqsMessageContext context,
         CancellationToken cancellationToken)
     {
-        var snsEnvelope = await _snsDecoder.DecodeAsync(record.Body, cancellationToken).ConfigureAwait(false);
-        var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
+        var s3Event = await _s3Decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
 
-        foreach (var s3Record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
+        foreach (var record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
         {
-            await _s3Processor.ProcessAsync(s3Record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
 
         return SqsRecordResult.Success;

--- a/samples/NativeAotSqsSnsS3Function/Function.cs
+++ b/samples/NativeAotSqsSnsS3Function/Function.cs
@@ -53,16 +53,16 @@ public sealed class SqsSnsS3Handler : ISqsRecordHandler
     }
 
     public async ValueTask<SqsRecordResult> HandleAsync(
-        SQSEvent.SQSMessage message,
+        SQSEvent.SQSMessage record,
         SqsMessageContext context,
         CancellationToken cancellationToken)
     {
-        var snsEnvelope = await _snsDecoder.DecodeAsync(message.Body, cancellationToken).ConfigureAwait(false);
+        var snsEnvelope = await _snsDecoder.DecodeAsync(record.Body, cancellationToken).ConfigureAwait(false);
         var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
 
-        foreach (var record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
+        foreach (var s3Record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
         {
-            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(s3Record, context, cancellationToken).ConfigureAwait(false);
         }
 
         return SqsRecordResult.Success;

--- a/samples/NativeAotSqsSnsS3Function/Function.cs
+++ b/samples/NativeAotSqsSnsS3Function/Function.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
 
 using Kralizek.Lambda;
 
@@ -15,15 +16,13 @@ using Microsoft.Extensions.Logging;
 
 namespace NativeAotSqsSnsS3Function;
 
-public sealed class Function : SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+public sealed class Function : SqsFunction<SqsSnsS3Handler>
 {
-    protected override void ConfigureFrameworkServices(IServiceCollection services) =>
-        services.AddSingleton(PayloadJsonSerializerContext.Default.SnsEnvelope);
-
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-        services.TryAddScoped<S3EventDispatcher>();
+        services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>>(
+            new JsonStringPayloadDecoder<SnsEnvelope>(PayloadJsonSerializerContext.Default.SnsEnvelope));
         services.TryAddSingleton<IStringPayloadDecoder<S3Event>>(
             new JsonStringPayloadDecoder<S3Event>(PayloadJsonSerializerContext.Default.S3Event));
     }
@@ -34,50 +33,39 @@ public sealed record SnsEnvelope
     public string Message { get; init; } = string.Empty;
 }
 
-public sealed class SnsEnvelopedS3DeliveryHandler : ISqsMessageHandler<SnsEnvelope>
+public sealed class SqsSnsS3Handler : ISqsRecordHandler
 {
-    private readonly IStringPayloadDecoder<S3Event> _decoder;
-    private readonly S3EventDispatcher _dispatcher;
-
-    public SnsEnvelopedS3DeliveryHandler(
-        IStringPayloadDecoder<S3Event> decoder,
-        S3EventDispatcher dispatcher)
-    {
-        _decoder = decoder;
-        _dispatcher = dispatcher;
-    }
-
-    public async ValueTask<SqsRecordResult> HandleAsync(
-        SnsEnvelope message,
-        SqsMessageContext context,
-        CancellationToken cancellationToken)
-    {
-        var s3Event = await _decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
-        await _dispatcher.DispatchAsync(s3Event, context, cancellationToken).ConfigureAwait(false);
-        return SqsRecordResult.Success;
-    }
-}
-
-public sealed class S3EventDispatcher
-{
+    private readonly IStringPayloadDecoder<SnsEnvelope> _snsDecoder;
+    private readonly IStringPayloadDecoder<S3Event> _s3Decoder;
     private readonly IRecordProcessor<
         S3Event.S3EventNotificationRecord,
         S3RecordResult,
-        RecordContext> _processor;
+        RecordContext> _s3Processor;
 
-    public S3EventDispatcher(
-        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> processor) =>
-        _processor = processor;
+    public SqsSnsS3Handler(
+        IStringPayloadDecoder<SnsEnvelope> snsDecoder,
+        IStringPayloadDecoder<S3Event> s3Decoder,
+        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> s3Processor)
+    {
+        _snsDecoder = snsDecoder;
+        _s3Decoder = s3Decoder;
+        _s3Processor = s3Processor;
+    }
 
-    public async ValueTask DispatchAsync(
-        S3Event s3Event,
-        RecordContext context,
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage message,
+        SqsMessageContext context,
         CancellationToken cancellationToken)
     {
+        var snsEnvelope = await _snsDecoder.DecodeAsync(message.Body, cancellationToken).ConfigureAwait(false);
+        var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
+
         foreach (var record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
         {
-            await _processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
+
+        return SqsRecordResult.Success;
     }
 }
 

--- a/samples/NativeAotSqsSnsS3Function/README.md
+++ b/samples/NativeAotSqsSnsS3Function/README.md
@@ -1,20 +1,21 @@
 # Native AOT SQS → SNS envelope → S3 sample
 
-Use this sample when S3 notifications are published to SNS, delivered to SQS using the standard SNS JSON envelope, and consumed by a Native AOT Lambda.
+Use this sample when S3 notifications are published to SNS, delivered to SQS using the standard SNS JSON envelope, and consumed by a Native AOT Lambda. The raw SQS handler owns the nested envelope decoding while S3 record handling continues through the framework's normal S3 processor.
 
 ```text
 S3 bucket
   → SNS topic (standard delivery)
   → SQS queue
   → SQSEvent
-  → SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
-  → decode SnsEnvelope.Message to S3Event
-  → S3EventDispatcher
-  → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
+  → SqsFunction<SqsSnsS3Handler>
+  → SqsSnsS3Handler
+      → decode SQSMessage.Body to SnsEnvelope
+      → decode SnsEnvelope.Message to S3Event
+      → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
   → S3ObjectEventHandler
 ```
 
-The application flow is the same as [SqsSnsS3Function](../SqsSnsS3Function/). The difference is that this project is an executable Native AOT Lambda and every JSON boundary uses source-generated metadata.
+The application flow is the same as [SqsSnsS3Function](../SqsSnsS3Function/). Native AOT changes how JSON metadata and the Lambda runtime boundary are supplied, not how the topology handler or S3 item handler are structured.
 
 ## The three JSON boundaries
 
@@ -26,7 +27,7 @@ There are three distinct serialization steps in this topology:
 
 `Program.cs` owns the Lambda Runtime API boundary through `LambdaJsonSerializerContext` and `SourceGeneratorLambdaJsonSerializer<TContext>`.
 
-`PayloadJsonSerializerContext` owns the two application payload types:
+`PayloadJsonSerializerContext` owns the two nested application payloads:
 
 ```csharp
 [JsonSerializable(typeof(SnsEnvelope))]
@@ -34,23 +35,19 @@ There are three distinct serialization steps in this topology:
 internal partial class PayloadJsonSerializerContext : JsonSerializerContext;
 ```
 
-`Function.ConfigureFrameworkServices` registers the generated metadata used by the outer SQS payload decoder:
+The nested decoders are registered explicitly with their generated `JsonTypeInfo<T>` instances:
 
 ```csharp
-protected override void ConfigureFrameworkServices(IServiceCollection services)
-{
-    services.AddSingleton(PayloadJsonSerializerContext.Default.SnsEnvelope);
-}
-```
+services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>>(
+    new JsonStringPayloadDecoder<SnsEnvelope>(PayloadJsonSerializerContext.Default.SnsEnvelope));
 
-The inner SNS `Message` decoding is registered explicitly with its generated `JsonTypeInfo<S3Event>` so DI cannot select a reflection-based `JsonStringPayloadDecoder<S3Event>` constructor:
-
-```csharp
 services.TryAddSingleton<IStringPayloadDecoder<S3Event>>(
     new JsonStringPayloadDecoder<S3Event>(PayloadJsonSerializerContext.Default.S3Event));
 ```
 
-The handler and record-processing contracts remain unchanged. `SnsEnvelopedS3DeliveryHandler`, `S3EventDispatcher`, and `S3ObjectEventHandler` use the same framework contracts as the non-AOT sample.
+This keeps both nested JSON boundaries AOT-safe without changing `SqsSnsS3Handler`. The handler receives the same decoder abstractions as the non-AOT sample, decodes both envelope levels, and delegates each S3 SDK record to `IRecordProcessor`.
+
+`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers the canonical S3 record-processing path. The processor preserves the S3 per-record DI scope, telemetry, adapter behavior, and `S3RecordContext` creation before invoking the ordinary `IS3ObjectEventHandler`.
 
 ## Publishing
 
@@ -62,4 +59,4 @@ dotnet publish samples/NativeAotSqsSnsS3Function -c Release -r linux-x64 --self-
 
 The included `aws-lambda-tools-defaults.json` contains matching Native AOT deployment defaults.
 
-For the complete SNS/SQS/S3 infrastructure sketch and an example payload, see [SqsSnsS3Function](../SqsSnsS3Function/).
+For the complete SNS/SQS/S3 infrastructure sketch and example payload, see [SqsSnsS3Function](../SqsSnsS3Function/). For the same topology with SNS Raw Message Delivery enabled, see [SqsRawSnsS3Function](../SqsRawSnsS3Function/); because its SQS body is already an `S3Event`, the typed SQS programming model remains the natural fit there.

--- a/samples/NativeAotSqsSnsS3Function/README.md
+++ b/samples/NativeAotSqsSnsS3Function/README.md
@@ -1,15 +1,14 @@
 # Native AOT SQS → SNS envelope → S3 sample
 
-Use this sample when S3 notifications are published to SNS, delivered to SQS using the standard SNS JSON envelope, and consumed by a Native AOT Lambda. The raw SQS handler owns the nested envelope decoding while S3 record handling continues through the framework's normal S3 processor.
+Use this sample when S3 notifications are published to SNS, delivered to SQS using the standard SNS JSON envelope, and consumed by a Native AOT Lambda. The SQS function decodes the outer SNS envelope as its typed payload, while the handler decodes the nested S3 event and delegates each S3 record to the framework's normal S3 processor.
 
 ```text
 S3 bucket
   → SNS topic (standard delivery)
   → SQS queue
   → SQSEvent
-  → SqsFunction<SqsSnsS3Handler>
+  → SqsFunction<SnsEnvelope, SqsSnsS3Handler>
   → SqsSnsS3Handler
-      → decode SQSMessage.Body to SnsEnvelope
       → decode SnsEnvelope.Message to S3Event
       → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
   → S3ObjectEventHandler
@@ -27,7 +26,7 @@ There are three distinct serialization steps in this topology:
 
 `Program.cs` owns the Lambda Runtime API boundary through `LambdaJsonSerializerContext` and `SourceGeneratorLambdaJsonSerializer<TContext>`.
 
-`PayloadJsonSerializerContext` owns the two nested application payloads:
+`PayloadJsonSerializerContext` owns the two application payload types:
 
 ```csharp
 [JsonSerializable(typeof(SnsEnvelope))]
@@ -35,17 +34,21 @@ There are three distinct serialization steps in this topology:
 internal partial class PayloadJsonSerializerContext : JsonSerializerContext;
 ```
 
-The nested decoders are registered explicitly with their generated `JsonTypeInfo<T>` instances:
+`Function.ConfigureFrameworkServices` registers the generated metadata used by the typed SQS decoder for the outer SNS envelope:
 
 ```csharp
-services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>>(
-    new JsonStringPayloadDecoder<SnsEnvelope>(PayloadJsonSerializerContext.Default.SnsEnvelope));
+protected override void ConfigureFrameworkServices(IServiceCollection services) =>
+    services.AddSingleton(PayloadJsonSerializerContext.Default.SnsEnvelope);
+```
 
+The nested SNS `Message` decoder is registered explicitly with generated `JsonTypeInfo<S3Event>`:
+
+```csharp
 services.TryAddSingleton<IStringPayloadDecoder<S3Event>>(
     new JsonStringPayloadDecoder<S3Event>(PayloadJsonSerializerContext.Default.S3Event));
 ```
 
-This keeps both nested JSON boundaries AOT-safe without changing `SqsSnsS3Handler`. The handler receives the same decoder abstractions as the non-AOT sample, decodes both envelope levels, and delegates each S3 SDK record to `IRecordProcessor`.
+`SqsSnsS3Handler` therefore has the same shape as the non-AOT sample: it receives a typed `SnsEnvelope`, decodes only the nested `S3Event`, and delegates each S3 SDK record to `IRecordProcessor`.
 
 `services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers the canonical S3 record-processing path. The processor preserves the S3 per-record DI scope, telemetry, adapter behavior, and `S3RecordContext` creation before invoking the ordinary `IS3ObjectEventHandler`.
 
@@ -59,4 +62,4 @@ dotnet publish samples/NativeAotSqsSnsS3Function -c Release -r linux-x64 --self-
 
 The included `aws-lambda-tools-defaults.json` contains matching Native AOT deployment defaults.
 
-For the complete SNS/SQS/S3 infrastructure sketch and example payload, see [SqsSnsS3Function](../SqsSnsS3Function/). For the same topology with SNS Raw Message Delivery enabled, see [SqsRawSnsS3Function](../SqsRawSnsS3Function/); because its SQS body is already an `S3Event`, the typed SQS programming model remains the natural fit there.
+For the complete SNS/SQS/S3 infrastructure sketch and example payload, see [SqsSnsS3Function](../SqsSnsS3Function/). For the same topology with SNS Raw Message Delivery enabled, see [SqsRawSnsS3Function](../SqsRawSnsS3Function/); in that shape the typed SQS payload is `S3Event` directly.

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,14 +11,14 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | A Lambda that consumes an event and returns no application response | [EventFunction](EventFunction/) | `EventFunction<TInput, THandler>`, handler DI, logging, and `EventContext` |
 | A Lambda with a typed request and response | [RequestFunction](RequestFunction/) | `RequestFunction<TInput, TOutput, THandler>` and `RequestContext` |
 | Native AOT hosting for a typed SQS function | [NativeAotSqsFunction](NativeAotSqsFunction/) | executable Lambda bootstrap, source-generated boundary metadata, and an AOT-safe nested JSON decoder |
-| Native AOT for S3 events delivered through an SNS envelope and SQS | [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) | raw SQS orchestration with source-generated metadata for both nested JSON payloads |
+| Native AOT for S3 events delivered through an SNS envelope and SQS | [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) | typed SNS-envelope decoding plus AOT-safe nested S3 event decoding |
 | OpenTelemetry instrumentation for a request/response Lambda | [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/) | wrapping the inherited request handler with `AWSLambdaWrapper.TraceAsync` and exporting the invocation span |
 | OpenTelemetry instrumentation for an event Lambda | [OpenTelemetryEventFunction](OpenTelemetryEventFunction/) | the same standard AWS Lambda OpenTelemetry wrapper pattern applied to `EventFunction` |
 | OpenTelemetry instrumentation for SQS record processing | [OpenTelemetrySqsFunction](OpenTelemetrySqsFunction/) | wrapping a typed SQS record function while preserving `SQSBatchResponse` and partial batch failures |
 | JSON messages from SQS | [SqsFunction](SqsFunction/) | typed payload decoding, `IRecordProcessor`-backed per-record scopes, and partial batch failures |
 | SQS messages without decoding the body | [RawSqsFunction](RawSqsFunction/) | raw record handling when the AWS envelope is the application contract |
 | S3 notifications delivered through SNS → SQS with raw message delivery | [SqsRawSnsS3Function](SqsRawSnsS3Function/) | typed `S3Event` payload decoding when the SQS body contains the S3 event directly |
-| S3 notifications delivered through SNS → SQS with the SNS envelope preserved | [SqsSnsS3Function](SqsSnsS3Function/) | raw SQS orchestration that decodes the SNS envelope and nested S3 event before delegating S3 records |
+| S3 notifications delivered through SNS → SQS with the SNS envelope preserved | [SqsSnsS3Function](SqsSnsS3Function/) | typed `SnsEnvelope` decoding followed by nested `S3Event` decoding and S3 record delegation |
 | JSON notifications from SNS | [SnsFunction](SnsFunction/) | typed payload decoding and SNS record handling |
 | SNS notifications without decoding the message | [RawSnsFunction](RawSnsFunction/) | raw SNS record handling |
 | A strongly typed EventBridge detail while retaining the full envelope | [EventBridgeFunction](EventBridgeFunction/) | `CloudWatchEvent<TDetail>` and EventBridge metadata |
@@ -40,7 +40,7 @@ Compare [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/), [OpenTele
 
 Compare [NativeAotSqsFunction](NativeAotSqsFunction/) with [SqsFunction](SqsFunction/). The handler and framework programming model remain the same; the Native AOT sample adds the executable runtime bootstrap, source-generated Lambda boundary metadata, and generated `JsonTypeInfo<T>` metadata for the nested application payload decoder.
 
-For a deeper nested payload, compare [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). Both use the same raw SQS topology handler and S3 record-processing model. Native AOT supplies generated metadata to the `SnsEnvelope` and `S3Event` decoders in addition to the Lambda `SQSEvent`/`SQSBatchResponse` boundary.
+For a deeper nested payload, compare [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). Both use the same typed `SnsEnvelope` handler and S3 record-processing model. Native AOT supplies generated metadata for the outer `SnsEnvelope`, the nested `S3Event`, and the Lambda `SQSEvent`/`SQSBatchResponse` boundary.
 
 ### Decoded vs raw messages
 
@@ -50,7 +50,7 @@ Compare [SqsFunction](SqsFunction/) with [RawSqsFunction](RawSqsFunction/), or [
 
 Compare [SqsRawSnsS3Function](SqsRawSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). The AWS topology is the same; the SNS subscription's `raw_message_delivery` setting changes the payload shape from `SQS body → S3Event` to `SQS body → SNS envelope → Message → S3Event`.
 
-When the SQS body is directly an `S3Event`, the typed SQS programming model is a natural fit. When the SNS envelope is preserved, the raw SQS handler owns both nested decoding stages as one topology-specific concern. Once either path reaches S3 records, both samples use the public `IRecordProcessor` to reuse the framework's normal S3 per-record scope, telemetry, handler activation, and context adaptation. The processor handles one inner record at a time; the outer SQS function remains responsible for iteration-level failure translation and the AWS retry boundary.
+Both use the typed SQS programming model for the payload that actually appears in `SQSMessage.Body`: `S3Event` for raw SNS delivery, `SnsEnvelope` when the SNS envelope is preserved. The enveloped sample then decodes the nested `S3Event` inside its handler. Once either path reaches S3 records, both use the public `IRecordProcessor` to reuse the framework's normal S3 per-record scope, telemetry, handler activation, and context adaptation. The processor handles one inner record at a time; the outer SQS function remains responsible for iteration-level failure translation and the AWS retry boundary.
 
 ### Queues vs streams
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -11,14 +11,14 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | A Lambda that consumes an event and returns no application response | [EventFunction](EventFunction/) | `EventFunction<TInput, THandler>`, handler DI, logging, and `EventContext` |
 | A Lambda with a typed request and response | [RequestFunction](RequestFunction/) | `RequestFunction<TInput, TOutput, THandler>` and `RequestContext` |
 | Native AOT hosting for a typed SQS function | [NativeAotSqsFunction](NativeAotSqsFunction/) | executable Lambda bootstrap, source-generated boundary metadata, and an AOT-safe nested JSON decoder |
-| Native AOT for S3 events delivered through an SNS envelope and SQS | [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) | source-generated metadata across the Lambda boundary and both nested JSON decoding layers |
+| Native AOT for S3 events delivered through an SNS envelope and SQS | [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) | raw SQS orchestration with source-generated metadata for both nested JSON payloads |
 | OpenTelemetry instrumentation for a request/response Lambda | [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/) | wrapping the inherited request handler with `AWSLambdaWrapper.TraceAsync` and exporting the invocation span |
 | OpenTelemetry instrumentation for an event Lambda | [OpenTelemetryEventFunction](OpenTelemetryEventFunction/) | the same standard AWS Lambda OpenTelemetry wrapper pattern applied to `EventFunction` |
 | OpenTelemetry instrumentation for SQS record processing | [OpenTelemetrySqsFunction](OpenTelemetrySqsFunction/) | wrapping a typed SQS record function while preserving `SQSBatchResponse` and partial batch failures |
 | JSON messages from SQS | [SqsFunction](SqsFunction/) | typed payload decoding, `IRecordProcessor`-backed per-record scopes, and partial batch failures |
 | SQS messages without decoding the body | [RawSqsFunction](RawSqsFunction/) | raw record handling when the AWS envelope is the application contract |
-| S3 notifications delivered through SNS → SQS with raw message delivery | [SqsRawSnsS3Function](SqsRawSnsS3Function/) | nested S3 record composition when the SQS body is the `S3Event` directly |
-| S3 notifications delivered through SNS → SQS with the SNS envelope preserved | [SqsSnsS3Function](SqsSnsS3Function/) | SNS-envelope decoding followed by nested S3 record composition |
+| S3 notifications delivered through SNS → SQS with raw message delivery | [SqsRawSnsS3Function](SqsRawSnsS3Function/) | typed `S3Event` payload decoding when the SQS body contains the S3 event directly |
+| S3 notifications delivered through SNS → SQS with the SNS envelope preserved | [SqsSnsS3Function](SqsSnsS3Function/) | raw SQS orchestration that decodes the SNS envelope and nested S3 event before delegating S3 records |
 | JSON notifications from SNS | [SnsFunction](SnsFunction/) | typed payload decoding and SNS record handling |
 | SNS notifications without decoding the message | [RawSnsFunction](RawSnsFunction/) | raw SNS record handling |
 | A strongly typed EventBridge detail while retaining the full envelope | [EventBridgeFunction](EventBridgeFunction/) | `CloudWatchEvent<TDetail>` and EventBridge metadata |
@@ -40,7 +40,7 @@ Compare [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/), [OpenTele
 
 Compare [NativeAotSqsFunction](NativeAotSqsFunction/) with [SqsFunction](SqsFunction/). The handler and framework programming model remain the same; the Native AOT sample adds the executable runtime bootstrap, source-generated Lambda boundary metadata, and generated `JsonTypeInfo<T>` metadata for the nested application payload decoder.
 
-For a deeper nested payload, compare [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). The application flow is unchanged, but Native AOT requires generated metadata for the outer `SnsEnvelope` and the inner `S3Event` in addition to the Lambda `SQSEvent`/`SQSBatchResponse` boundary.
+For a deeper nested payload, compare [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). Both use the same raw SQS topology handler and S3 record-processing model. Native AOT supplies generated metadata to the `SnsEnvelope` and `S3Event` decoders in addition to the Lambda `SQSEvent`/`SQSBatchResponse` boundary.
 
 ### Decoded vs raw messages
 
@@ -50,7 +50,7 @@ Compare [SqsFunction](SqsFunction/) with [RawSqsFunction](RawSqsFunction/), or [
 
 Compare [SqsRawSnsS3Function](SqsRawSnsS3Function/) with [SqsSnsS3Function](SqsSnsS3Function/). The AWS topology is the same; the SNS subscription's `raw_message_delivery` setting changes the payload shape from `SQS body → S3Event` to `SQS body → SNS envelope → Message → S3Event`.
 
-Both samples use the public `IRecordProcessor` to reuse the framework's normal S3 per-record scope and handler-activation semantics inside an outer SQS record. The processor handles one inner record at a time; the outer SQS function remains responsible for iteration-level failure translation and the AWS retry boundary.
+When the SQS body is directly an `S3Event`, the typed SQS programming model is a natural fit. When the SNS envelope is preserved, the raw SQS handler owns both nested decoding stages as one topology-specific concern. Once either path reaches S3 records, both samples use the public `IRecordProcessor` to reuse the framework's normal S3 per-record scope, telemetry, handler activation, and context adaptation. The processor handles one inner record at a time; the outer SQS function remains responsible for iteration-level failure translation and the AWS retry boundary.
 
 ### Queues vs streams
 

--- a/samples/SqsSnsS3Function/Function.cs
+++ b/samples/SqsSnsS3Function/Function.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,7 +54,7 @@ public sealed class SqsSnsS3Handler : ISqsMessageHandler<SnsEnvelope>
     {
         var s3Event = await _s3Decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
 
-        foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
+        foreach (var record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
         {
             await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }

--- a/samples/SqsSnsS3Function/Function.cs
+++ b/samples/SqsSnsS3Function/Function.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
 using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
 
 using Kralizek.Lambda;
 
@@ -16,12 +17,12 @@ using Microsoft.Extensions.Logging;
 
 namespace SqsSnsS3Function;
 
-public sealed class Function : SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
+public sealed class Function : SqsFunction<SqsSnsS3Handler>
 {
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-        services.TryAddScoped<S3EventDispatcher>();
+        services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>, JsonStringPayloadDecoder<SnsEnvelope>>();
         services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
     }
 }
@@ -31,50 +32,39 @@ public sealed record SnsEnvelope
     public string Message { get; init; } = string.Empty;
 }
 
-public sealed class SnsEnvelopedS3DeliveryHandler : ISqsMessageHandler<SnsEnvelope>
+public sealed class SqsSnsS3Handler : ISqsRecordHandler
 {
-    private readonly IStringPayloadDecoder<S3Event> _decoder;
-    private readonly S3EventDispatcher _dispatcher;
-
-    public SnsEnvelopedS3DeliveryHandler(
-        IStringPayloadDecoder<S3Event> decoder,
-        S3EventDispatcher dispatcher)
-    {
-        _decoder = decoder;
-        _dispatcher = dispatcher;
-    }
-
-    public async ValueTask<SqsRecordResult> HandleAsync(
-        SnsEnvelope message,
-        SqsMessageContext context,
-        CancellationToken cancellationToken)
-    {
-        var s3Event = await _decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
-        await _dispatcher.DispatchAsync(s3Event, context, cancellationToken).ConfigureAwait(false);
-        return SqsRecordResult.Success;
-    }
-}
-
-public sealed class S3EventDispatcher
-{
+    private readonly IStringPayloadDecoder<SnsEnvelope> _snsDecoder;
+    private readonly IStringPayloadDecoder<S3Event> _s3Decoder;
     private readonly IRecordProcessor<
         S3Event.S3EventNotificationRecord,
         S3RecordResult,
-        RecordContext> _processor;
+        RecordContext> _s3Processor;
 
-    public S3EventDispatcher(
-        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> processor) =>
-        _processor = processor;
+    public SqsSnsS3Handler(
+        IStringPayloadDecoder<SnsEnvelope> snsDecoder,
+        IStringPayloadDecoder<S3Event> s3Decoder,
+        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> s3Processor)
+    {
+        _snsDecoder = snsDecoder;
+        _s3Decoder = s3Decoder;
+        _s3Processor = s3Processor;
+    }
 
-    public async ValueTask DispatchAsync(
-        S3Event s3Event,
-        RecordContext context,
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage message,
+        SqsMessageContext context,
         CancellationToken cancellationToken)
     {
+        var snsEnvelope = await _snsDecoder.DecodeAsync(message.Body, cancellationToken).ConfigureAwait(false);
+        var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
+
         foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
         {
-            await _processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
+
+        return SqsRecordResult.Success;
     }
 }
 

--- a/samples/SqsSnsS3Function/Function.cs
+++ b/samples/SqsSnsS3Function/Function.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
 using Amazon.Lambda.S3Events;
-using Amazon.Lambda.SQSEvents;
 
 using Kralizek.Lambda;
 
@@ -17,12 +16,11 @@ using Microsoft.Extensions.Logging;
 
 namespace SqsSnsS3Function;
 
-public sealed class Function : SqsFunction<SqsSnsS3Handler>
+public sealed class Function : SqsFunction<SnsEnvelope, SqsSnsS3Handler>
 {
     protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddS3ObjectEventProcessing<S3ObjectEventHandler>();
-        services.TryAddSingleton<IStringPayloadDecoder<SnsEnvelope>, JsonStringPayloadDecoder<SnsEnvelope>>();
         services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
     }
 }
@@ -32,9 +30,8 @@ public sealed record SnsEnvelope
     public string Message { get; init; } = string.Empty;
 }
 
-public sealed class SqsSnsS3Handler : ISqsRecordHandler
+public sealed class SqsSnsS3Handler : ISqsMessageHandler<SnsEnvelope>
 {
-    private readonly IStringPayloadDecoder<SnsEnvelope> _snsDecoder;
     private readonly IStringPayloadDecoder<S3Event> _s3Decoder;
     private readonly IRecordProcessor<
         S3Event.S3EventNotificationRecord,
@@ -42,26 +39,23 @@ public sealed class SqsSnsS3Handler : ISqsRecordHandler
         RecordContext> _s3Processor;
 
     public SqsSnsS3Handler(
-        IStringPayloadDecoder<SnsEnvelope> snsDecoder,
         IStringPayloadDecoder<S3Event> s3Decoder,
         IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> s3Processor)
     {
-        _snsDecoder = snsDecoder;
         _s3Decoder = s3Decoder;
         _s3Processor = s3Processor;
     }
 
     public async ValueTask<SqsRecordResult> HandleAsync(
-        SQSEvent.SQSMessage record,
+        SnsEnvelope message,
         SqsMessageContext context,
         CancellationToken cancellationToken)
     {
-        var snsEnvelope = await _snsDecoder.DecodeAsync(record.Body, cancellationToken).ConfigureAwait(false);
-        var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
+        var s3Event = await _s3Decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
 
-        foreach (var s3Record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
+        foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
         {
-            await _s3Processor.ProcessAsync(s3Record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
 
         return SqsRecordResult.Success;

--- a/samples/SqsSnsS3Function/Function.cs
+++ b/samples/SqsSnsS3Function/Function.cs
@@ -52,16 +52,16 @@ public sealed class SqsSnsS3Handler : ISqsRecordHandler
     }
 
     public async ValueTask<SqsRecordResult> HandleAsync(
-        SQSEvent.SQSMessage message,
+        SQSEvent.SQSMessage record,
         SqsMessageContext context,
         CancellationToken cancellationToken)
     {
-        var snsEnvelope = await _snsDecoder.DecodeAsync(message.Body, cancellationToken).ConfigureAwait(false);
+        var snsEnvelope = await _snsDecoder.DecodeAsync(record.Body, cancellationToken).ConfigureAwait(false);
         var s3Event = await _s3Decoder.DecodeAsync(snsEnvelope.Message, cancellationToken).ConfigureAwait(false);
 
-        foreach (var record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
+        foreach (var s3Record in s3Event.Records ?? new List<S3Event.S3EventNotificationRecord>())
         {
-            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            await _s3Processor.ProcessAsync(s3Record, context, cancellationToken).ConfigureAwait(false);
         }
 
         return SqsRecordResult.Success;

--- a/samples/SqsSnsS3Function/README.md
+++ b/samples/SqsSnsS3Function/README.md
@@ -1,15 +1,14 @@
 # SQS → SNS envelope → S3 sample
 
-Use this sample when S3 notifications are published to SNS, delivered to SQS using the **standard SNS JSON envelope**, and finally consumed by Lambda. The SQS handler owns the topology-specific envelope decoding and delegates each inner S3 record to the framework's normal S3 record-processing pipeline.
+Use this sample when S3 notifications are published to SNS, delivered to SQS using the **standard SNS JSON envelope**, and finally consumed by Lambda. The SQS function decodes the outer SNS envelope as its typed message payload, while the handler owns the nested S3 event decoding and delegates each inner S3 record to the framework's normal S3 record-processing pipeline.
 
 ```text
 S3 bucket
   → SNS topic (standard delivery)
   → SQS queue
   → SQSEvent
-  → SqsFunction<SqsSnsS3Handler>
+  → SqsFunction<SnsEnvelope, SqsSnsS3Handler>
   → SqsSnsS3Handler
-      → decode SQSMessage.Body to SnsEnvelope
       → decode SnsEnvelope.Message to S3Event
       → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
   → S3ObjectEventHandler
@@ -86,13 +85,13 @@ SQSEvent
 
 ## How the pieces fit
 
-`Function` derives from the raw `SqsFunction<SqsSnsS3Handler>` specialization because the SQS body contains more than one nested application payload. The framework still owns SQS record iteration, per-message handling, and partial-batch failure translation.
+`Function` derives from `SqsFunction<SnsEnvelope, SqsSnsS3Handler>`, so the framework decodes each SQS body into the sample's minimal `SnsEnvelope` model before invoking the handler. The framework still owns SQS record iteration, per-message handling, and partial-batch failure translation.
 
-`SqsSnsS3Handler` handles one outer SQS record. It decodes `SQSMessage.Body` to the sample's minimal `SnsEnvelope`, decodes `SnsEnvelope.Message` to `S3Event`, then iterates the inner S3 records. This keeps the complete SNS/S3 envelope chain in one topology-specific handler.
+`SqsSnsS3Handler` handles one typed SNS envelope. It decodes `SnsEnvelope.Message` to `S3Event`, then iterates the inner S3 records and delegates each one to the registered `IRecordProcessor`.
 
 `SnsEnvelope` contains only the `Message` property because that is the only SNS metadata this sample needs. Applications can extend the model when they need more of the envelope.
 
-`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers the canonical S3 record processor. `SqsSnsS3Handler` calls that `IRecordProcessor` once for each inner S3 record, preserving the framework's S3 per-record DI scope, telemetry, adapter behavior, and `S3RecordContext` creation.
+`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers the canonical S3 record processor. The processor preserves the framework's S3 per-record DI scope, telemetry, adapter behavior, and `S3RecordContext` creation.
 
 `S3ObjectEventHandler` remains an ordinary `IS3ObjectEventHandler`. Its `S3RecordContext` carries forward the outer context properties, so `context.GetSqsMessage()` can still recover the containing SQS message without sharing scoped services between the outer and inner handlers.
 
@@ -100,9 +99,9 @@ Inner S3 records are processed sequentially and fail fast. The AWS retry/acknowl
 
 ## Look at
 
-- `Function` for raw SQS hosting plus SNS/S3 decoder and S3 processor registration.
-- `SqsSnsS3Handler` for the complete nested-envelope decoding and inner-record orchestration.
+- `Function` for typed SNS-envelope decoding, S3 processor registration, and the inner S3 decoder registration.
+- `SqsSnsS3Handler` for nested S3 event decoding and inner-record orchestration.
 - `SnsEnvelope` for the minimal preserved SNS envelope.
 - `S3ObjectEventHandler` for the normal S3 application-handler contract and propagated SQS context.
 
-For the same topology with SNS Raw Message Delivery enabled, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/). In that shape the SQS body is already an `S3Event`, so the typed `SqsFunction<S3Event, ...>` programming model remains the natural fit.
+For the same topology with SNS Raw Message Delivery enabled, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/). In that shape the SQS body is already an `S3Event`, so the typed payload changes from `SnsEnvelope` to `S3Event` and no additional nested decoder is required.

--- a/samples/SqsSnsS3Function/README.md
+++ b/samples/SqsSnsS3Function/README.md
@@ -1,16 +1,17 @@
 # SQS → SNS envelope → S3 sample
 
-Use this sample when S3 notifications are published to SNS, delivered to SQS using the **standard SNS JSON envelope**, and finally consumed by Lambda. It demonstrates the extra decoding layer plus nested S3 record composition.
+Use this sample when S3 notifications are published to SNS, delivered to SQS using the **standard SNS JSON envelope**, and finally consumed by Lambda. The SQS handler owns the topology-specific envelope decoding and delegates each inner S3 record to the framework's normal S3 record-processing pipeline.
 
 ```text
 S3 bucket
   → SNS topic (standard delivery)
   → SQS queue
   → SQSEvent
-  → SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>
-  → decode SnsEnvelope.Message to S3Event
-  → S3EventDispatcher
-  → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
+  → SqsFunction<SqsSnsS3Handler>
+  → SqsSnsS3Handler
+      → decode SQSMessage.Body to SnsEnvelope
+      → decode SnsEnvelope.Message to S3Event
+      → IRecordProcessor<S3 record, S3RecordResult, RecordContext>
   → S3ObjectEventHandler
 ```
 
@@ -83,17 +84,15 @@ SQSEvent
                 └── S3 record
 ```
 
-`Function` derives from `SqsFunction<SnsEnvelope, SnsEnvelopedS3DeliveryHandler>`, so the outer SQS integration first decodes the body into the sample's minimal `SnsEnvelope` model.
-
 ## How the pieces fit
+
+`Function` derives from the raw `SqsFunction<SqsSnsS3Handler>` specialization because the SQS body contains more than one nested application payload. The framework still owns SQS record iteration, per-message handling, and partial-batch failure translation.
+
+`SqsSnsS3Handler` handles one outer SQS record. It decodes `SQSMessage.Body` to the sample's minimal `SnsEnvelope`, decodes `SnsEnvelope.Message` to `S3Event`, then iterates the inner S3 records. This keeps the complete SNS/S3 envelope chain in one topology-specific handler.
 
 `SnsEnvelope` contains only the `Message` property because that is the only SNS metadata this sample needs. Applications can extend the model when they need more of the envelope.
 
-`SnsEnvelopedS3DeliveryHandler` handles one **outer SQS record**. It uses `IStringPayloadDecoder<S3Event>` to decode `SnsEnvelope.Message`, then passes the resulting S3 event to `S3EventDispatcher`. This second decoding step is the main application difference from raw SNS delivery.
-
-`S3EventDispatcher` expands `S3Event.Records` and calls `IRecordProcessor` once for each inner S3 record. The processor gives every inner record its own DI scope and runs the same canonical S3 adapter/application-handler path used by direct S3 functions.
-
-`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers that S3 record-processing path, while the explicit `IStringPayloadDecoder<S3Event>` registration handles the SNS `Message` string.
+`services.AddS3ObjectEventProcessing<S3ObjectEventHandler>()` registers the canonical S3 record processor. `SqsSnsS3Handler` calls that `IRecordProcessor` once for each inner S3 record, preserving the framework's S3 per-record DI scope, telemetry, adapter behavior, and `S3RecordContext` creation.
 
 `S3ObjectEventHandler` remains an ordinary `IS3ObjectEventHandler`. Its `S3RecordContext` carries forward the outer context properties, so `context.GetSqsMessage()` can still recover the containing SQS message without sharing scoped services between the outer and inner handlers.
 
@@ -101,10 +100,9 @@ Inner S3 records are processed sequentially and fail fast. The AWS retry/acknowl
 
 ## Look at
 
-- `Function` for the outer SQS specialization, S3 processor registration, and S3 decoder registration.
+- `Function` for raw SQS hosting plus SNS/S3 decoder and S3 processor registration.
+- `SqsSnsS3Handler` for the complete nested-envelope decoding and inner-record orchestration.
 - `SnsEnvelope` for the minimal preserved SNS envelope.
-- `SnsEnvelopedS3DeliveryHandler` for the second decoding layer.
-- `S3EventDispatcher` for nested iteration through `IRecordProcessor`.
 - `S3ObjectEventHandler` for the normal S3 application-handler contract and propagated SQS context.
 
-For the same topology with SNS Raw Message Delivery enabled, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/). The infrastructure difference is essentially one subscription setting; the payload and decoding path are what change.
+For the same topology with SNS Raw Message Delivery enabled, compare [SqsRawSnsS3Function](../SqsRawSnsS3Function/). In that shape the SQS body is already an `S3Event`, so the typed `SqsFunction<S3Event, ...>` programming model remains the natural fit.


### PR DESCRIPTION
## What changed

- keeps both SNS-envelope S3 samples on the typed SQS programming model
- uses `SnsEnvelope` as the outer typed payload
- uses a single `SqsSnsS3Handler` to decode the inner `S3Event`
- delegates each inner S3 record to the public `IRecordProcessor`
- preserves the normal S3 per-record scope, telemetry, adapter behavior, and `S3RecordContext`
- leaves the raw-message-delivery sample unchanged, where the typed SQS payload is `S3Event`
- updates the sample documentation to describe the final programming model

## Why

The SNS envelope is the payload stored in the SQS body, so the framework can decode it before invoking the handler. The handler then owns only the nested S3 event decoding and inner-record orchestration. This removes the extra dispatcher layer without giving up typed SQS handling.

## Native AOT

The Native AOT sample uses the same handler shape. It additionally supplies generated metadata for `SnsEnvelope`, generated metadata for the nested `S3Event` decoder, and the Lambda runtime bootstrap metadata.

## Validation

CI validates formatting, build, tests, SonarQube analysis, and the existing Native AOT sample checks.