### PR TITLE
Add benchmark infrastructure

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -33,6 +33,10 @@ jobs:
     permissions:
       contents: read
 
+    defaults:
+      run:
+        working-directory: benchmarks
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -40,10 +44,13 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          global-json-file: global.json
+          global-json-file: benchmarks/global.json
+
+      - name: Verify SDK
+        run: test "$(dotnet --version)" = "10.0.400"
 
       - name: Restore
-        run: dotnet restore benchmarks/Benchmarks.slnx
+        run: dotnet restore Benchmarks.slnx
 
       - name: Build
-        run: dotnet build benchmarks/Benchmarks.slnx --configuration Release --no-restore
+        run: dotnet build Benchmarks.slnx --configuration Release --no-restore --warnaserror

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -1,0 +1,49 @@
+name: Benchmark validation
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'global.json'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - 'Directory.Build.props'
+      - 'Directory.Packages.props'
+      - 'global.json'
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+jobs:
+  build:
+    name: Build benchmark solution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore benchmarks/Benchmarks.slnx
+
+      - name: Build
+        run: dotnet build benchmarks/Benchmarks.slnx --configuration Release --no-restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [master]
-  pull_request: {}
+    paths-ignore:
+      - 'benchmarks/**'
+  pull_request:
+    paths-ignore:
+      - 'benchmarks/**'
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@ name: CI
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - 'benchmarks/**'
-  pull_request:
-    paths-ignore:
-      - 'benchmarks/**'
+  pull_request: {}
   release:
     types: [published]
   workflow_dispatch:
@@ -466,83 +462,87 @@ jobs:
             [ -z "$file" ] || test ! -e "$project/$file"
           done < <(jq -r '.[]?' <<< "$MUST_NOT_EXIST")
 
-          while IFS=$'\t' read -r file pattern; do
-            [ -z "$file" ] || grep -q -- "$pattern" "$project/$file"
-          done < <(jq -r '.[]? | [.file, .pattern] | @tsv' <<< "$MUST_MATCH")
+          while IFS= read -r pattern; do
+            if [ -n "$pattern" ] && ! grep -R -E -q -- "$pattern" "$project"; then
+              echo "Expected generated content to match regex: $pattern"
+              exit 1
+            fi
+          done < <(jq -r '.[]?' <<< "$MUST_MATCH")
 
-          while IFS=$'\t' read -r file pattern; do
-            [ -z "$file" ] || ! grep -q -- "$pattern" "$project/$file"
-          done < <(jq -r '.[]? | [.file, .pattern] | @tsv' <<< "$MUST_NOT_MATCH")
+          while IFS= read -r pattern; do
+            if [ -n "$pattern" ] && grep -R -E -q -- "$pattern" "$project"; then
+              echo "Expected generated content not to match regex: $pattern"
+              exit 1
+            fi
+          done < <(jq -r '.[]?' <<< "$MUST_NOT_MATCH")
 
       - name: Configure smoke-test package sources
         shell: bash
         run: |
-          set -euo pipefail
-
-          project="$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
-          cat > "$project/NuGet.Config" <<EOF
+          local_feed=$(realpath $ARTIFACTS_PATH/packages)
+          cat > "$RUNNER_TEMP/lambda-template-smoke/NuGet.config" <<EOF
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
             <packageSources>
               <clear />
-              <add key="local" value="$GITHUB_WORKSPACE/$ARTIFACTS_PATH/packages" />
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+              <add key="local" value="$local_feed" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
             </packageSources>
+            <packageSourceMapping>
+              <packageSource key="local">
+                <package pattern="Kralizek.Lambda.*" />
+              </packageSource>
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
+            </packageSourceMapping>
           </configuration>
           EOF
 
       - name: Restore generated project
-        run: dotnet restore "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+        run: >-
+          dotnet restore
+          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+          --configfile "$RUNNER_TEMP/lambda-template-smoke/NuGet.config"
+          --packages "$RUNNER_TEMP/lambda-template-smoke/packages"
 
       - name: Restore Native AOT runtime assets
         if: matrix.aot == true
-        env:
-          PROJECT_PATH: ${{ runner.temp }}/lambda-template-smoke/${{ matrix.projectName }}/${{ matrix.projectName }}.csproj
-          EXPECTED_RID: ${{ matrix.runtimeIdentifier || 'linux-x64' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          project_rid=$(dotnet msbuild "$PROJECT_PATH" -nologo -getProperty:RuntimeIdentifier)
-
-          if [ "$project_rid" != "$EXPECTED_RID" ]; then
-            echo "Expected RuntimeIdentifier '$EXPECTED_RID' but generated project resolved '$project_rid'."
-            exit 1
-          fi
-
-          dotnet restore "$PROJECT_PATH" --runtime "$project_rid"
+        run: >-
+          dotnet restore
+          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+          --runtime linux-x64
+          --configfile "$RUNNER_TEMP/lambda-template-smoke/NuGet.config"
+          --packages "$RUNNER_TEMP/lambda-template-smoke/packages"
 
       - name: Build generated project
-        run: dotnet build "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}" --configuration $CONFIGURATION --no-restore --warnaserror
+        run: >-
+          dotnet build
+          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+          --configuration $CONFIGURATION
+          --no-restore
+          --warnaserror
 
       - name: Publish Native AOT generated project
         if: matrix.aot == true
-        env:
-          PROJECT_PATH: ${{ runner.temp }}/lambda-template-smoke/${{ matrix.projectName }}/${{ matrix.projectName }}.csproj
-        shell: bash
-        run: |
-          set -euo pipefail
+        run: >-
+          dotnet publish
+          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+          --configuration $CONFIGURATION
+          --runtime linux-x64
+          --self-contained true
+          --no-restore
+          --warnaserror
 
-          project_rid=$(dotnet msbuild "$PROJECT_PATH" -nologo -getProperty:RuntimeIdentifier)
-
-          if [ -z "$project_rid" ]; then
-            echo "Native AOT smoke test project does not define RuntimeIdentifier."
-            exit 1
-          fi
-
-          dotnet publish "$PROJECT_PATH" \
-            --configuration "$CONFIGURATION" \
-            --runtime "$project_rid" \
-            --no-restore \
-            --warnaserror
-
-  native-aot-samples:
+  validate-native-aot-sample:
     name: Native AOT sample (${{ matrix.projectName }})
-    needs: prepare-native-aot-samples
-    if: needs.prepare-native-aot-samples.result == 'success'
+    needs: [prepare-version, prepare-template-smoke-tests, prepare-native-aot-samples]
+    if: needs.prepare-template-smoke-tests.outputs.mode != 'pr' && needs.prepare-native-aot-samples.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      MinVerVersionOverride: ${{ needs.prepare-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-native-aot-samples.outputs.matrix) }}
@@ -550,52 +550,226 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/*.props
+            **/*.targets
 
-      - name: Restore
-        run: dotnet restore ${{ matrix.projectPath }} --runtime linux-x64
-
-      - name: Publish
+      - name: Restore Native AOT sample
         run: >-
-          dotnet publish ${{ matrix.projectPath }}
+          dotnet restore
+          ${{ matrix.projectPath }}
+          --runtime linux-x64
+
+      - name: Build Native AOT sample
+        run: >-
+          dotnet build
+          ${{ matrix.projectPath }}
+          --configuration $CONFIGURATION
+          --no-restore
+          --warnaserror
+
+      - name: Publish Native AOT sample
+        run: >-
+          dotnet publish
+          ${{ matrix.projectPath }}
           --configuration $CONFIGURATION
           --runtime linux-x64
+          --self-contained true
           --no-restore
           --warnaserror
 
   publish:
     name: Publish
-    needs: [prepare-version, validate-and-pack, template-smoke-test, native-aot-samples]
-    if: >-
-      always() &&
-      (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none' && !inputs.dry_run)) &&
-      needs.validate-and-pack.result == 'success' &&
-      needs.template-smoke-test.result == 'success' &&
-      (needs.native-aot-samples.result == 'success' || needs.native-aot-samples.result == 'skipped')
+    needs: [prepare-version, validate-and-pack, template-smoke-test, validate-native-aot-sample]
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'release') && needs.validate-native-aot-sample.result == 'success'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      packages: write
       id-token: write
 
     steps:
-      - name: Download packages
-        uses: actions/download-artifact@v8
+      - name: Validate manual release source
+        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.ref != 'refs/heads/master'
+        run: |
+          echo "Manual releases must be dispatched from master."
+          exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v6
         with:
-          name: nuget-packages
-          path: ${{ env.ARTIFACTS_PATH }}/packages
+          fetch-depth: 0
+
+      - name: Validate GitHub release metadata
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag is not a supported Semantic Versioning tag: $RELEASE_TAG"
+            exit 1
+          fi
+
+          release_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
+          head_commit=$(git rev-parse HEAD)
+
+          if [ "$release_commit" != "$head_commit" ]; then
+            echo "Release tag $RELEASE_TAG does not point to the checked-out commit."
+            exit 1
+          fi
+
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            if [ "$RELEASE_IS_PRERELEASE" != "true" ]; then
+              echo "Prerelease tag $RELEASE_TAG must be published as a GitHub prerelease."
+              exit 1
+            fi
+          elif [ "$RELEASE_IS_PRERELEASE" != "false" ]; then
+            echo "Stable tag $RELEASE_TAG must not be published as a GitHub prerelease."
+            exit 1
+          fi
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
-      - name: Publish packages
+      - name: Download packages
+        uses: actions/download-artifact@v8
+        with:
+          name: nuget-packages
+          path: ./artifacts/packages
+
+      - name: Read release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          package=$(ls ./artifacts/packages/Kralizek.Lambda.Templates.*.nupkg)
+          nuspec=$(unzip -p "$package" '*.nuspec')
+          package_version=$(printf '%s\n' "$nuspec" | sed -n 's:.*<version>\(.*\)</version>.*:\1:p' | head -n 1)
+
+          if [ -z "$package_version" ]; then
+            echo "Could not determine the package version."
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="v$package_version"
+
+            if [ "${{ inputs.release_channel }}" != "none" ] && [ "$package_version" != "${{ needs.prepare-version.outputs.version }}" ]; then
+              echo "Packed version $package_version does not match selected prerelease version ${{ needs.prepare-version.outputs.version }}."
+              exit 1
+            fi
+          else
+            release_tag="${{ github.event.release.tag_name }}"
+            tag_version="${release_tag#v}"
+
+            if [ "$tag_version" != "$package_version" ]; then
+              echo "Release tag version $tag_version does not match packed version $package_version."
+              exit 1
+            fi
+          fi
+
+          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
+
+      - name: Dry-run release summary
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
+        shell: bash
+        run: |
+          echo "Dry run: no packages or GitHub release will be published."
+          echo "Release channel: ${{ inputs.release_channel }}"
+          echo "Package version: $PACKAGE_VERSION"
+
+          if [ "${{ inputs.release_channel }}" = "alpha" ]; then
+            echo "Production release would publish to GitHub Packages and create a GitHub prerelease."
+          elif [ "${{ inputs.release_channel }}" = "beta" ] || [ "${{ inputs.release_channel }}" = "rc" ]; then
+            echo "Production release would publish to GitHub Packages and NuGet.org and create a GitHub prerelease."
+          else
+            echo "Production run would publish the package to GitHub Packages only."
+          fi
+
+      - name: Configure GitHub Packages source
+        if: github.event_name == 'release' || !inputs.dry_run
         run: >-
-          dotnet nuget push "$ARTIFACTS_PATH/packages/*.nupkg"
-          --source https://api.nuget.org/v3/index.json
-          --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --name github
+          --username "${{ github.actor }}"
+          --password "${{ github.token }}"
+          --store-password-in-clear-text
+
+      - name: Publish to GitHub Packages
+        if: github.event_name == 'release' || !inputs.dry_run
+        run: >-
+          dotnet nuget push
+          "./artifacts/packages/*.nupkg"
+          --source github
+          --api-key "${{ github.token }}"
           --skip-duplicate
+
+      # Alpha releases stay on GitHub for explicit/manual consumption.
+      # Beta, RC, and stable releases are also published to NuGet.org.
+      - name: Log in to NuGet.org
+        if: >-
+          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
+          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
+        id: nuget-login
+        uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: Kralizek
+
+      - name: Publish to NuGet.org
+        if: >-
+          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
+        run: >-
+          dotnet nuget push
+          "./artifacts/packages/*.nupkg"
+          --source https://api.nuget.org/v3/index.json
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --skip-duplicate
+
+      - name: Ensure GitHub prerelease exists
+        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists."
+            exit 0
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --repo "${{ github.repository }}" \
+            --target "$GITHUB_SHA" \
+            --title "$RELEASE_TAG" \
+            --generate-notes \
+            --prerelease
+
+      - name: Attach packages to the GitHub release
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "$RELEASE_TAG"
+          ./artifacts/packages/*.nupkg
+          ./artifacts/packages/*.snupkg
+          --repo "${{ github.repository }}"
+          --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [master]
-  pull_request: {}
+    paths-ignore:
+      - 'benchmarks/**'
+  pull_request:
+    paths-ignore:
+      - 'benchmarks/**'
   release:
     types: [published]
   workflow_dispatch:
@@ -462,87 +466,83 @@ jobs:
             [ -z "$file" ] || test ! -e "$project/$file"
           done < <(jq -r '.[]?' <<< "$MUST_NOT_EXIST")
 
-          while IFS= read -r pattern; do
-            if [ -n "$pattern" ] && ! grep -R -E -q -- "$pattern" "$project"; then
-              echo "Expected generated content to match regex: $pattern"
-              exit 1
-            fi
-          done < <(jq -r '.[]?' <<< "$MUST_MATCH")
+          while IFS=$'\t' read -r file pattern; do
+            [ -z "$file" ] || grep -q -- "$pattern" "$project/$file"
+          done < <(jq -r '.[]? | [.file, .pattern] | @tsv' <<< "$MUST_MATCH")
 
-          while IFS= read -r pattern; do
-            if [ -n "$pattern" ] && grep -R -E -q -- "$pattern" "$project"; then
-              echo "Expected generated content not to match regex: $pattern"
-              exit 1
-            fi
-          done < <(jq -r '.[]?' <<< "$MUST_NOT_MATCH")
+          while IFS=$'\t' read -r file pattern; do
+            [ -z "$file" ] || ! grep -q -- "$pattern" "$project/$file"
+          done < <(jq -r '.[]? | [.file, .pattern] | @tsv' <<< "$MUST_NOT_MATCH")
 
       - name: Configure smoke-test package sources
         shell: bash
         run: |
-          local_feed=$(realpath $ARTIFACTS_PATH/packages)
-          cat > "$RUNNER_TEMP/lambda-template-smoke/NuGet.config" <<EOF
+          set -euo pipefail
+
+          project="$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
+          cat > "$project/NuGet.Config" <<EOF
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>
             <packageSources>
               <clear />
-              <add key="local" value="$local_feed" />
-              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+              <add key="local" value="$GITHUB_WORKSPACE/$ARTIFACTS_PATH/packages" />
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
             </packageSources>
-            <packageSourceMapping>
-              <packageSource key="local">
-                <package pattern="Kralizek.Lambda.*" />
-              </packageSource>
-              <packageSource key="nuget.org">
-                <package pattern="*" />
-              </packageSource>
-            </packageSourceMapping>
           </configuration>
           EOF
 
       - name: Restore generated project
-        run: >-
-          dotnet restore
-          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
-          --configfile "$RUNNER_TEMP/lambda-template-smoke/NuGet.config"
-          --packages "$RUNNER_TEMP/lambda-template-smoke/packages"
+        run: dotnet restore "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
 
       - name: Restore Native AOT runtime assets
         if: matrix.aot == true
-        run: >-
-          dotnet restore
-          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
-          --runtime linux-x64
-          --configfile "$RUNNER_TEMP/lambda-template-smoke/NuGet.config"
-          --packages "$RUNNER_TEMP/lambda-template-smoke/packages"
+        env:
+          PROJECT_PATH: ${{ runner.temp }}/lambda-template-smoke/${{ matrix.projectName }}/${{ matrix.projectName }}.csproj
+          EXPECTED_RID: ${{ matrix.runtimeIdentifier || 'linux-x64' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          project_rid=$(dotnet msbuild "$PROJECT_PATH" -nologo -getProperty:RuntimeIdentifier)
+
+          if [ "$project_rid" != "$EXPECTED_RID" ]; then
+            echo "Expected RuntimeIdentifier '$EXPECTED_RID' but generated project resolved '$project_rid'."
+            exit 1
+          fi
+
+          dotnet restore "$PROJECT_PATH" --runtime "$project_rid"
 
       - name: Build generated project
-        run: >-
-          dotnet build
-          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
-          --configuration $CONFIGURATION
-          --no-restore
-          --warnaserror
+        run: dotnet build "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}" --configuration $CONFIGURATION --no-restore --warnaserror
 
       - name: Publish Native AOT generated project
         if: matrix.aot == true
-        run: >-
-          dotnet publish
-          "$RUNNER_TEMP/lambda-template-smoke/${{ matrix.projectName }}"
-          --configuration $CONFIGURATION
-          --runtime linux-x64
-          --self-contained true
-          --no-restore
-          --warnaserror
+        env:
+          PROJECT_PATH: ${{ runner.temp }}/lambda-template-smoke/${{ matrix.projectName }}/${{ matrix.projectName }}.csproj
+        shell: bash
+        run: |
+          set -euo pipefail
 
-  validate-native-aot-sample:
+          project_rid=$(dotnet msbuild "$PROJECT_PATH" -nologo -getProperty:RuntimeIdentifier)
+
+          if [ -z "$project_rid" ]; then
+            echo "Native AOT smoke test project does not define RuntimeIdentifier."
+            exit 1
+          fi
+
+          dotnet publish "$PROJECT_PATH" \
+            --configuration "$CONFIGURATION" \
+            --runtime "$project_rid" \
+            --no-restore \
+            --warnaserror
+
+  native-aot-samples:
     name: Native AOT sample (${{ matrix.projectName }})
-    needs: [prepare-version, prepare-template-smoke-tests, prepare-native-aot-samples]
-    if: needs.prepare-template-smoke-tests.outputs.mode != 'pr' && needs.prepare-native-aot-samples.result == 'success'
+    needs: prepare-native-aot-samples
+    if: needs.prepare-native-aot-samples.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      MinVerVersionOverride: ${{ needs.prepare-version.outputs.version }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-native-aot-samples.outputs.matrix) }}
@@ -550,226 +550,52 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
-          cache: true
-          cache-dependency-path: |
-            **/*.csproj
-            **/*.props
-            **/*.targets
 
-      - name: Restore Native AOT sample
-        run: >-
-          dotnet restore
-          ${{ matrix.projectPath }}
-          --runtime linux-x64
+      - name: Restore
+        run: dotnet restore ${{ matrix.projectPath }} --runtime linux-x64
 
-      - name: Build Native AOT sample
+      - name: Publish
         run: >-
-          dotnet build
-          ${{ matrix.projectPath }}
-          --configuration $CONFIGURATION
-          --no-restore
-          --warnaserror
-
-      - name: Publish Native AOT sample
-        run: >-
-          dotnet publish
-          ${{ matrix.projectPath }}
+          dotnet publish ${{ matrix.projectPath }}
           --configuration $CONFIGURATION
           --runtime linux-x64
-          --self-contained true
           --no-restore
           --warnaserror
 
   publish:
     name: Publish
-    needs: [prepare-version, validate-and-pack, template-smoke-test, validate-native-aot-sample]
-    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'release') && needs.validate-native-aot-sample.result == 'success'
+    needs: [prepare-version, validate-and-pack, template-smoke-test, native-aot-samples]
+    if: >-
+      always() &&
+      (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_channel != 'none' && !inputs.dry_run)) &&
+      needs.validate-and-pack.result == 'success' &&
+      needs.template-smoke-test.result == 'success' &&
+      (needs.native-aot-samples.result == 'success' || needs.native-aot-samples.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      packages: write
+      contents: read
       id-token: write
 
     steps:
-      - name: Validate manual release source
-        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && github.ref != 'refs/heads/master'
-        run: |
-          echo "Manual releases must be dispatched from master."
-          exit 1
-
-      - name: Checkout
-        uses: actions/checkout@v6
+      - name: Download packages
+        uses: actions/download-artifact@v8
         with:
-          fetch-depth: 0
-
-      - name: Validate GitHub release metadata
-        if: github.event_name == 'release'
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Release tag is not a supported Semantic Versioning tag: $RELEASE_TAG"
-            exit 1
-          fi
-
-          release_commit=$(git rev-parse "$RELEASE_TAG^{commit}")
-          head_commit=$(git rev-parse HEAD)
-
-          if [ "$release_commit" != "$head_commit" ]; then
-            echo "Release tag $RELEASE_TAG does not point to the checked-out commit."
-            exit 1
-          fi
-
-          if [[ "$RELEASE_TAG" == *-* ]]; then
-            if [ "$RELEASE_IS_PRERELEASE" != "true" ]; then
-              echo "Prerelease tag $RELEASE_TAG must be published as a GitHub prerelease."
-              exit 1
-            fi
-          elif [ "$RELEASE_IS_PRERELEASE" != "false" ]; then
-            echo "Stable tag $RELEASE_TAG must not be published as a GitHub prerelease."
-            exit 1
-          fi
+          name: nuget-packages
+          path: ${{ env.ARTIFACTS_PATH }}/packages
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
-      - name: Download packages
-        uses: actions/download-artifact@v8
-        with:
-          name: nuget-packages
-          path: ./artifacts/packages
-
-      - name: Read release metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          package=$(ls ./artifacts/packages/Kralizek.Lambda.Templates.*.nupkg)
-          nuspec=$(unzip -p "$package" '*.nuspec')
-          package_version=$(printf '%s\n' "$nuspec" | sed -n 's:.*<version>\(.*\)</version>.*:\1:p' | head -n 1)
-
-          if [ -z "$package_version" ]; then
-            echo "Could not determine the package version."
-            exit 1
-          fi
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            release_tag="v$package_version"
-
-            if [ "${{ inputs.release_channel }}" != "none" ] && [ "$package_version" != "${{ needs.prepare-version.outputs.version }}" ]; then
-              echo "Packed version $package_version does not match selected prerelease version ${{ needs.prepare-version.outputs.version }}."
-              exit 1
-            fi
-          else
-            release_tag="${{ github.event.release.tag_name }}"
-            tag_version="${release_tag#v}"
-
-            if [ "$tag_version" != "$package_version" ]; then
-              echo "Release tag version $tag_version does not match packed version $package_version."
-              exit 1
-            fi
-          fi
-
-          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=$release_tag" >> "$GITHUB_ENV"
-
-      - name: Dry-run release summary
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        shell: bash
-        run: |
-          echo "Dry run: no packages or GitHub release will be published."
-          echo "Release channel: ${{ inputs.release_channel }}"
-          echo "Package version: $PACKAGE_VERSION"
-
-          if [ "${{ inputs.release_channel }}" = "alpha" ]; then
-            echo "Production release would publish to GitHub Packages and create a GitHub prerelease."
-          elif [ "${{ inputs.release_channel }}" = "beta" ] || [ "${{ inputs.release_channel }}" = "rc" ]; then
-            echo "Production release would publish to GitHub Packages and NuGet.org and create a GitHub prerelease."
-          else
-            echo "Production run would publish the package to GitHub Packages only."
-          fi
-
-      - name: Configure GitHub Packages source
-        if: github.event_name == 'release' || !inputs.dry_run
+      - name: Publish packages
         run: >-
-          dotnet nuget add source
-          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-          --name github
-          --username "${{ github.actor }}"
-          --password "${{ github.token }}"
-          --store-password-in-clear-text
-
-      - name: Publish to GitHub Packages
-        if: github.event_name == 'release' || !inputs.dry_run
-        run: >-
-          dotnet nuget push
-          "./artifacts/packages/*.nupkg"
-          --source github
-          --api-key "${{ github.token }}"
-          --skip-duplicate
-
-      # Alpha releases stay on GitHub for explicit/manual consumption.
-      # Beta, RC, and stable releases are also published to NuGet.org.
-      - name: Log in to NuGet.org
-        if: >-
-          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
-        id: nuget-login
-        uses: nuget/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        with:
-          user: Kralizek
-
-      - name: Publish to NuGet.org
-        if: >-
-          (github.event_name == 'release' && !contains(github.event.release.tag_name, '-alpha.')) ||
-          (github.event_name == 'workflow_dispatch' && !inputs.dry_run && (inputs.release_channel == 'beta' || inputs.release_channel == 'rc'))
-        run: >-
-          dotnet nuget push
-          "./artifacts/packages/*.nupkg"
+          dotnet nuget push "$ARTIFACTS_PATH/packages/*.nupkg"
           --source https://api.nuget.org/v3/index.json
-          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --api-key ${{ secrets.NUGET_API_KEY }}
           --skip-duplicate
-
-      - name: Ensure GitHub prerelease exists
-        if: github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "Release $RELEASE_TAG already exists."
-            exit 0
-          fi
-
-          gh release create "$RELEASE_TAG" \
-            --repo "${{ github.repository }}" \
-            --target "$GITHUB_SHA" \
-            --title "$RELEASE_TAG" \
-            --generate-notes \
-            --prerelease
-
-      - name: Attach packages to the GitHub release
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: >-
-          gh release upload "$RELEASE_TAG"
-          ./artifacts/packages/*.nupkg
-          ./artifacts/packages/*.snupkg
-          --repo "${{ github.repository }}"
-          --clobber

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Amazon.Lambda.SNSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />

--- a/benchmarks/BenchmarkWorkloads/BenchmarkWorkloads.csproj
+++ b/benchmarks/BenchmarkWorkloads/BenchmarkWorkloads.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/benchmarks/BenchmarkWorkloads/BenchmarkWorkloads.csproj
+++ b/benchmarks/BenchmarkWorkloads/BenchmarkWorkloads.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/benchmarks/BenchmarkWorkloads/UppercaseWorkload.cs
+++ b/benchmarks/BenchmarkWorkloads/UppercaseWorkload.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace BenchmarkWorkloads;
+
+public interface IRequestTarget
+{
+    Task<string> InvokeAsync(string input);
+}
+
+public static class UppercaseWorkload
+{
+    public static string Execute(string input) => input.ToUpperInvariant();
+}

--- a/benchmarks/Benchmarks.slnx
+++ b/benchmarks/Benchmarks.slnx
@@ -1,0 +1,9 @@
+<Solution>
+  <Folder Name="/benchmarks/">
+    <Project Path="BenchmarkWorkloads/BenchmarkWorkloads.csproj" />
+    <Project Path="Benchmarks/Benchmarks.csproj" />
+    <Project Path="RawSdkTarget/RawSdkTarget.csproj" />
+    <Project Path="V5Target/V5Target.csproj" />
+    <Project Path="V6Target/V6Target.csproj" />
+  </Folder>
+</Solution>

--- a/benchmarks/Benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
+    <ProjectReference Include="..\RawSdkTarget\RawSdkTarget.csproj" />
+    <ProjectReference Include="..\V6Target\V6Target.csproj" />
+    <ProjectReference Include="..\V5Target\V5Target.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyMetadata Include="V5TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\V5Target\bin\$(Configuration)\net6.0\V5Target.dll'))" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks/Benchmarks.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AssemblyMetadata Include="V5TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)\..\V5Target\bin\$(Configuration)\net6.0\V5Target.dll'))" />
+    <AssemblyMetadata Include="V5TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../V5Target/bin/$(Configuration)/net6.0/V5Target.dll'))" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using System.Linq;

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class RequestBenchmarks
+{
+    private const string Input = "lambda benchmark";
+
+    private readonly IRequestTarget _rawSdk = new RawSdkTarget.UppercaseTarget();
+    private readonly IRequestTarget _v6 = new V6Target.UppercaseTarget();
+
+    private V5TargetLoadContext? _v5LoadContext;
+    private IRequestTarget? _v5;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var v5TargetAssemblyPath = typeof(RequestBenchmarks).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "V5TargetAssemblyPath")
+            .Value;
+
+        if (string.IsNullOrWhiteSpace(v5TargetAssemblyPath) || !File.Exists(v5TargetAssemblyPath))
+        {
+            throw new FileNotFoundException("The V5 target assembly was not built.", v5TargetAssemblyPath);
+        }
+
+        _v5LoadContext = new V5TargetLoadContext(v5TargetAssemblyPath);
+        var assembly = _v5LoadContext.LoadFromAssemblyPath(v5TargetAssemblyPath);
+        var targetType = assembly.GetType("V5Target.UppercaseTarget", throwOnError: true)!;
+        _v5 = (IRequestTarget)Activator.CreateInstance(targetType)!;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _v5 = null;
+        _v5LoadContext?.Unload();
+        _v5LoadContext = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<string> RawSdk() => _rawSdk.InvokeAsync(Input);
+
+    [Benchmark]
+    public Task<string> V5() => _v5!.InvokeAsync(Input);
+
+    [Benchmark]
+    public Task<string> V6() => _v6.InvokeAsync(Input);
+
+    private sealed class V5TargetLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public V5TargetLoadContext(string targetAssemblyPath)
+            : base(nameof(V5TargetLoadContext), isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(targetAssemblyPath);
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name == typeof(IRequestTarget).Assembly.GetName().Name)
+            {
+                return typeof(IRequestTarget).Assembly;
+            }
+
+            var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+        }
+    }
+}

--- a/benchmarks/Directory.Build.props
+++ b/benchmarks/Directory.Build.props
@@ -1,9 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+<Project>
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
 </Project>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -12,13 +12,21 @@ This directory contains performance benchmarks for the Lambda Template libraries
 
 V5 and V6 both contain an assembly named `Kralizek.Lambda.Template`. The benchmark host therefore does not reference V5 directly. It loads `V5Target` in an isolated `AssemblyLoadContext` and shares only the neutral `BenchmarkWorkloads` contract. Target loading is performed during benchmark setup and is not part of the measured operation.
 
+## Toolchain
+
+The benchmark subtree pins .NET SDK 10.0.400 through `benchmarks/global.json` and uses C# 14 for every benchmark project, regardless of target framework. Target frameworks describe the runtime/API surface being exercised; they do not select an older compiler for benchmark source code.
+
+Run benchmark commands from the `benchmarks` directory so the benchmark-specific SDK pin is applied.
+
 ## Running locally
 
-Build and run benchmarks in Release configuration from the repository root:
+Build and run benchmarks in Release configuration:
 
 ```bash
-dotnet build benchmarks/Benchmarks.slnx --configuration Release
-dotnet run --project benchmarks/Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*RequestBenchmarks*"
+cd benchmarks
+dotnet --version # must report 10.0.400
+dotnet build Benchmarks.slnx --configuration Release
+dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*RequestBenchmarks*"
 ```
 
 BenchmarkDotNet writes its normal artifacts under `BenchmarkDotNet.Artifacts`.
@@ -36,7 +44,7 @@ Publishable performance measurements must be collected on controlled local hardw
 
 Keep the machine on external power where applicable and avoid material background workloads while collecting results. Comparisons over time should use the same reference machine and execution conditions whenever possible.
 
-The benchmark-validation GitHub Actions workflow only restores and builds this solution. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
+The benchmark-validation GitHub Actions workflow only restores and builds this solution. It verifies the pinned SDK before building. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
 
 ## Current coverage
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,49 @@
+# Benchmarks
+
+This directory contains performance benchmarks for the Lambda Template libraries. It has its own solution so benchmark-only projects and dependencies do not become part of the normal product-development solution.
+
+## Layout
+
+- `BenchmarkWorkloads` contains dependency-free application workloads shared by every target.
+- `RawSdkTarget` implements the workload as a plain AWS Lambda handler.
+- `V5Target` is pinned to `Kralizek.Lambda.Template` 5.0.0 and keeps its original .NET 6 dependency graph isolated from the current source tree.
+- `V6Target` references the current projects under `src/` directly.
+- `Benchmarks` contains the BenchmarkDotNet runner and comparisons.
+
+V5 and V6 both contain an assembly named `Kralizek.Lambda.Template`. The benchmark host therefore does not reference V5 directly. It loads `V5Target` in an isolated `AssemblyLoadContext` and shares only the neutral `BenchmarkWorkloads` contract. Target loading is performed during benchmark setup and is not part of the measured operation.
+
+## Running locally
+
+Build and run benchmarks in Release configuration from the repository root:
+
+```bash
+dotnet build benchmarks/Benchmarks.slnx --configuration Release
+dotnet run --project benchmarks/Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*RequestBenchmarks*"
+```
+
+BenchmarkDotNet writes its normal artifacts under `BenchmarkDotNet.Artifacts`.
+
+## Reproducibility
+
+Publishable performance measurements must be collected on controlled local hardware, not GitHub-hosted runners. When sharing results, record at least:
+
+- git commit SHA;
+- CPU and memory;
+- operating system;
+- .NET SDK/runtime version;
+- power/performance mode;
+- the exact BenchmarkDotNet command and filters used.
+
+Keep the machine on external power where applicable and avoid material background workloads while collecting results. Comparisons over time should use the same reference machine and execution conditions whenever possible.
+
+The benchmark-validation GitHub Actions workflow only restores and builds this solution. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
+
+## Current coverage
+
+The initial request benchmark uses a trivial uppercase workload to compare:
+
+- a plain AWS Lambda handler (`RawSdk`), used as the BenchmarkDotNet baseline;
+- the published v5 runtime (`V5`);
+- the current v6 source tree (`V6`).
+
+The workload itself is shared so the comparison focuses on invocation-framework overhead rather than different application implementations.

--- a/benchmarks/RawSdkTarget/RawSdkTarget.csproj
+++ b/benchmarks/RawSdkTarget/RawSdkTarget.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.TestUtilities" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/RawSdkTarget/UppercaseTarget.cs
+++ b/benchmarks/RawSdkTarget/UppercaseTarget.cs
@@ -21,6 +21,8 @@ public sealed class UppercaseTarget : IRequestTarget
 
 public sealed class UppercaseFunction
 {
+#pragma warning disable S2325 // Keep the raw handler instance-based so all benchmark targets use the same invocation shape.
     public Task<string> FunctionHandlerAsync(string input, ILambdaContext context) =>
         Task.FromResult(UppercaseWorkload.Execute(input));
+#pragma warning restore S2325
 }

--- a/benchmarks/RawSdkTarget/UppercaseTarget.cs
+++ b/benchmarks/RawSdkTarget/UppercaseTarget.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+namespace RawSdkTarget;
+
+public sealed class UppercaseTarget : IRequestTarget
+{
+    private readonly UppercaseFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+
+    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, _context);
+}
+
+public sealed class UppercaseFunction
+{
+    public Task<string> FunctionHandlerAsync(string input, ILambdaContext context) =>
+        Task.FromResult(UppercaseWorkload.Execute(input));
+}

--- a/benchmarks/V5Target/UppercaseTarget.cs
+++ b/benchmarks/V5Target/UppercaseTarget.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace V5Target;
+
+public sealed class UppercaseTarget : IRequestTarget
+{
+    private readonly UppercaseFunction _function = new();
+
+    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, null!);
+}
+
+public sealed class UppercaseFunction : RequestResponseFunction<string, string>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        RegisterHandler<UppercaseHandler>(services);
+}
+
+public sealed class UppercaseHandler : IRequestResponseHandler<string, string>
+{
+    public Task<string> HandleAsync(string? input, ILambdaContext context) =>
+        Task.FromResult(UppercaseWorkload.Execute(input!));
+}

--- a/benchmarks/V5Target/UppercaseTarget.cs
+++ b/benchmarks/V5Target/UppercaseTarget.cs
@@ -1,8 +1,10 @@
 #nullable enable
 
+using System;
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
 
 using BenchmarkWorkloads;
 
@@ -15,8 +17,12 @@ namespace V5Target;
 public sealed class UppercaseTarget : IRequestTarget
 {
     private readonly UppercaseFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
 
-    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, null!);
+    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, _context);
 }
 
 public sealed class UppercaseFunction : RequestResponseFunction<string, string>

--- a/benchmarks/V5Target/UppercaseTarget.cs
+++ b/benchmarks/V5Target/UppercaseTarget.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Threading.Tasks;
 
 using Amazon.Lambda.Core;

--- a/benchmarks/V5Target/V5Target.csproj
+++ b/benchmarks/V5Target/V5Target.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kralizek.Lambda.Template" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/V5Target/V5Target.csproj
+++ b/benchmarks/V5Target/V5Target.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="5.0.0" />
   </ItemGroup>
 

--- a/benchmarks/V6Target/UppercaseTarget.cs
+++ b/benchmarks/V6Target/UppercaseTarget.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+namespace V6Target;
+
+public sealed class UppercaseTarget : IRequestTarget
+{
+    private readonly UppercaseFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+
+    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, _context);
+}
+
+public sealed class UppercaseFunction : RequestFunction<string, string, UppercaseHandler>;
+
+public sealed class UppercaseHandler : IRequestHandler<string, string>
+{
+    public ValueTask<string> HandleAsync(string input, RequestContext context, CancellationToken cancellationToken) =>
+        new(UppercaseWorkload.Execute(input));
+}

--- a/benchmarks/V6Target/V6Target.csproj
+++ b/benchmarks/V6Target/V6Target.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.TestUtilities" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/global.json
+++ b/benchmarks/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "disable"
+  }
+}


### PR DESCRIPTION
## Summary

- add a self-contained `benchmarks/Benchmarks.slnx` with non-shipping benchmark project names
- add shared request workload plus raw SDK, v5, and current v6 targets
- isolate the published v5 runtime in a separate `AssemblyLoadContext` so it can coexist with the current source assembly without `extern alias`
- add an initial BenchmarkDotNet request comparison using raw SDK as the baseline
- add build-only benchmark validation CI scoped to benchmark-relevant paths
- document controlled local execution and reproducibility expectations

## Why

Consumers have asked for performance comparisons, especially v5 to v6 and v6 to the direct AWS Lambda programming model. This establishes the harness before expanding into record, batch, envelope, failure, AOT, and OpenTelemetry scenarios.

Performance measurements are intentionally not executed on GitHub-hosted agents. CI only proves that the benchmark solution restores and builds; publishable numbers are collected on controlled local hardware.

## Validation

The benchmark validation workflow will restore and build `benchmarks/Benchmarks.slnx` in Release configuration. This execution environment cannot reach GitHub/NuGet directly, so GitHub Actions is the first compiler validation for the branch.

Closes #78