### PR TITLE
Add SQS performance benchmarks

### DIFF
--- a/benchmarks/BenchmarkWorkloads/SqsWorkload.cs
+++ b/benchmarks/BenchmarkWorkloads/SqsWorkload.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+
+namespace BenchmarkWorkloads;
+
+public interface ISqsTarget
+{
+    Task<int> InvokeAsync(int batchSize);
+}
+
+public sealed class SqsBenchmarkMessage
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+public static class SqsWorkload
+{
+    public const string Body = """{"Message":"lambda benchmark"}""";
+
+    public static string Execute(SqsBenchmarkMessage message) => message.Message.ToUpperInvariant();
+}

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -1,10 +1,5 @@
 #nullable enable
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
 using System.Threading.Tasks;
 
 using BenchmarkDotNet.Attributes;
@@ -18,9 +13,9 @@ public class RequestBenchmarks
 {
     private const string Input = "lambda benchmark";
 
-    private TargetLoadContext? _rawSdkLoadContext;
-    private TargetLoadContext? _v5LoadContext;
-    private TargetLoadContext? _v6LoadContext;
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
     private IRequestTarget? _rawSdk;
     private IRequestTarget? _v5;
     private IRequestTarget? _v6;
@@ -28,9 +23,13 @@ public class RequestBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        (_rawSdkLoadContext, _rawSdk) = LoadTarget("RawSdkTargetAssemblyPath", "RawSdkTarget.UppercaseTarget");
-        (_v5LoadContext, _v5) = LoadTarget("V5TargetAssemblyPath", "V5Target.UppercaseTarget");
-        (_v6LoadContext, _v6) = LoadTarget("V6TargetAssemblyPath", "V6Target.UppercaseTarget");
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<IRequestTarget>("RawSdkTarget.UppercaseTarget");
+        _v5 = _v5Session.CreateTarget<IRequestTarget>("V5Target.UppercaseTarget");
+        _v6 = _v6Session.CreateTarget<IRequestTarget>("V6Target.UppercaseTarget");
     }
 
     [GlobalCleanup]
@@ -40,13 +39,13 @@ public class RequestBenchmarks
         _v5 = null;
         _v6 = null;
 
-        _rawSdkLoadContext?.Unload();
-        _v5LoadContext?.Unload();
-        _v6LoadContext?.Unload();
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
 
-        _rawSdkLoadContext = null;
-        _v5LoadContext = null;
-        _v6LoadContext = null;
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
     }
 
     [Benchmark(Baseline = true)]
@@ -57,48 +56,4 @@ public class RequestBenchmarks
 
     [Benchmark]
     public Task<string> V6() => _v6!.InvokeAsync(Input);
-
-    private static (TargetLoadContext LoadContext, IRequestTarget Target) LoadTarget(
-        string metadataKey,
-        string targetTypeName)
-    {
-        var targetAssemblyPath = typeof(RequestBenchmarks).Assembly
-            .GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(attribute => attribute.Key == metadataKey)
-            .Value;
-
-        if (string.IsNullOrWhiteSpace(targetAssemblyPath) || !File.Exists(targetAssemblyPath))
-        {
-            throw new FileNotFoundException($"The benchmark target assembly for '{metadataKey}' was not built.", targetAssemblyPath);
-        }
-
-        var loadContext = new TargetLoadContext(targetAssemblyPath, targetTypeName);
-        var assembly = loadContext.LoadFromAssemblyPath(targetAssemblyPath);
-        var targetType = assembly.GetType(targetTypeName, throwOnError: true)!;
-        var target = (IRequestTarget)Activator.CreateInstance(targetType)!;
-
-        return (loadContext, target);
-    }
-
-    private sealed class TargetLoadContext : AssemblyLoadContext
-    {
-        private readonly AssemblyDependencyResolver _resolver;
-
-        public TargetLoadContext(string targetAssemblyPath, string name)
-            : base(name, isCollectible: true)
-        {
-            _resolver = new AssemblyDependencyResolver(targetAssemblyPath);
-        }
-
-        protected override Assembly? Load(AssemblyName assemblyName)
-        {
-            if (assemblyName.Name == typeof(IRequestTarget).Assembly.GetName().Name)
-            {
-                return typeof(IRequestTarget).Assembly;
-            }
-
-            var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
-            return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
-        }
-    }
 }

--- a/benchmarks/Benchmarks/SqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsBenchmarks.cs
@@ -1,0 +1,66 @@
+#nullable enable
+
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class SqsBenchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsTarget? _rawSdk;
+    private ISqsTarget? _v5Typed;
+    private ISqsTarget? _v6Raw;
+    private ISqsTarget? _v6Typed;
+
+    [Params(1, 10, 100)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.UppercaseSqsTarget");
+        _v5Typed = _v5Session.CreateTarget<ISqsTarget>("V5Target.UppercaseTypedSqsTarget");
+        _v6Raw = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseRawSqsTarget");
+        _v6Typed = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseTypedSqsTarget");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5Typed = null;
+        _v6Raw = null;
+        _v6Typed = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdk() => _rawSdk!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V5Typed() => _v5Typed!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6Raw() => _v6Raw!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6Typed() => _v6Typed!.InvokeAsync(BatchSize);
+}

--- a/benchmarks/Benchmarks/TargetSession.cs
+++ b/benchmarks/Benchmarks/TargetSession.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+internal sealed class TargetSession : IDisposable
+{
+    private readonly TargetLoadContext _loadContext;
+    private readonly string _targetAssemblyPath;
+
+    private TargetSession(string targetAssemblyPath, string name)
+    {
+        _targetAssemblyPath = targetAssemblyPath;
+        _loadContext = new TargetLoadContext(targetAssemblyPath, name);
+    }
+
+    public static TargetSession Create(string metadataKey)
+    {
+        var targetAssemblyPath = typeof(TargetSession).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == metadataKey)
+            .Value;
+
+        if (string.IsNullOrWhiteSpace(targetAssemblyPath) || !File.Exists(targetAssemblyPath))
+        {
+            throw new FileNotFoundException($"The benchmark target assembly for '{metadataKey}' was not built.", targetAssemblyPath);
+        }
+
+        return new TargetSession(targetAssemblyPath, metadataKey);
+    }
+
+    public TContract CreateTarget<TContract>(string targetTypeName)
+        where TContract : class
+    {
+        var assembly = _loadContext.LoadFromAssemblyPath(_targetAssemblyPath);
+        var targetType = assembly.GetType(targetTypeName, throwOnError: true)!;
+        return (TContract)Activator.CreateInstance(targetType)!;
+    }
+
+    public void Dispose() => _loadContext.Unload();
+
+    private sealed class TargetLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public TargetLoadContext(string targetAssemblyPath, string name)
+            : base(name, isCollectible: true)
+        {
+            _resolver = new AssemblyDependencyResolver(targetAssemblyPath);
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name == typeof(IRequestTarget).Assembly.GetName().Name)
+            {
+                return typeof(IRequestTarget).Assembly;
+            }
+
+            var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+        }
+    }
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,8 +5,8 @@ This directory contains performance benchmarks for the Lambda Template libraries
 ## Layout
 
 - `BenchmarkWorkloads` contains dependency-free application workloads shared by every target.
-- `RawSdkTarget` implements the workload as a plain AWS Lambda handler.
-- `V5Target` is pinned to `Kralizek.Lambda.Template` 5.0.0 and keeps its original .NET 6 dependency graph isolated from the current source tree.
+- `RawSdkTarget` implements the workloads as plain AWS Lambda handlers.
+- `V5Target` is pinned to the published v5 packages and keeps its original .NET 6 dependency graph isolated from the current source tree.
 - `V6Target` references the current projects under `src/` directly.
 - `Benchmarks` contains the BenchmarkDotNet benchmark host and comparisons.
 
@@ -38,6 +38,7 @@ Use BenchmarkDotNet filters when developing or investigating a specific benchmar
 
 ```bash
 dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*RequestBenchmarks*"
+dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*SqsBenchmarks*"
 ```
 
 All normal BenchmarkDotNet command-line options remain available. BenchmarkDotNet owns benchmark discovery, filtering, exporters, jobs, diagnosers, and artifact generation.
@@ -60,10 +61,23 @@ The benchmark-validation GitHub Actions workflow only restores and builds this s
 
 ## Current coverage
 
-The initial request benchmark uses a trivial uppercase workload to compare:
+### Request functions
+
+The request benchmark uses a trivial uppercase workload to compare:
 
 - a plain AWS Lambda handler (`RawSdk`), used as the BenchmarkDotNet baseline;
 - the published v5 runtime (`V5`);
 - the current v6 source tree (`V6`).
 
 The workload itself is shared so the comparison focuses on invocation-framework overhead rather than different application implementations.
+
+### SQS functions
+
+The SQS benchmark measures batches of 1, 10, and 100 records and compares:
+
+- a plain AWS Lambda SQS handler (`RawSdk`), used as the BenchmarkDotNet baseline;
+- the published v5 typed SQS function (`V5Typed`);
+- the current v6 raw SQS function (`V6Raw`);
+- the current v6 typed SQS function (`V6Typed`).
+
+Every target receives an equivalent pre-built SQS envelope. Envelope construction and target loading happen during benchmark setup so the measured operation focuses on dispatch, decoding, record handling, and response construction.

--- a/benchmarks/RawSdkTarget/RawSdkTarget.csproj
+++ b/benchmarks/RawSdkTarget/RawSdkTarget.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" />
   </ItemGroup>
 

--- a/benchmarks/RawSdkTarget/SqsTarget.cs
+++ b/benchmarks/RawSdkTarget/SqsTarget.cs
@@ -36,7 +36,7 @@ public sealed class UppercaseSqsFunction
 
         foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
         {
-            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body);
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
             _ = SqsWorkload.Execute(message);
         }
 

--- a/benchmarks/RawSdkTarget/SqsTarget.cs
+++ b/benchmarks/RawSdkTarget/SqsTarget.cs
@@ -36,7 +36,7 @@ public sealed class UppercaseSqsFunction
 
         foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
         {
-            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body);
             _ = SqsWorkload.Execute(message);
         }
 

--- a/benchmarks/RawSdkTarget/SqsTarget.cs
+++ b/benchmarks/RawSdkTarget/SqsTarget.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+namespace RawSdkTarget;
+
+public sealed class UppercaseSqsTarget : ISqsTarget
+{
+    private readonly UppercaseSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class UppercaseSqsFunction
+{
+    public Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+            _ = SqsWorkload.Execute(message);
+        }
+
+        return Task.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        });
+    }
+}
+
+internal static class SqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsWorkload.Body
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V5Target/SqsTarget.cs
+++ b/benchmarks/V5Target/SqsTarget.cs
@@ -1,0 +1,69 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace V5Target;
+
+public sealed class UppercaseSqsTarget : ISqsTarget
+{
+    private readonly UppercaseSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return 0;
+    }
+}
+
+public sealed class UppercaseSqsFunction : EventFunction<SQSEvent>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        services.UseQueueMessageHandler<SqsBenchmarkMessage, UppercaseSqsHandler>();
+}
+
+public sealed class UppercaseSqsHandler : IMessageHandler<SqsBenchmarkMessage>
+{
+    public Task HandleAsync(SqsBenchmarkMessage? message, ILambdaContext context)
+    {
+        _ = SqsWorkload.Execute(message!);
+        return Task.CompletedTask;
+    }
+}
+
+internal static class SqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsWorkload.Body
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V5Target/V5Target.csproj
+++ b/benchmarks/V5Target/V5Target.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="5.0.0" />
+    <PackageReference Include="Kralizek.Lambda.Template.Sqs" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+namespace V6Target;
+
+public sealed class UppercaseRawSqsTarget : ISqsTarget
+{
+    private readonly UppercaseRawSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class UppercaseTypedSqsTarget : ISqsTarget
+{
+    private readonly UppercaseTypedSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class UppercaseRawSqsFunction : SqsFunction<UppercaseRawSqsHandler>;
+
+public sealed class UppercaseRawSqsHandler : ISqsRecordHandler
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage record,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+        _ = SqsWorkload.Execute(message);
+
+        return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+public sealed class UppercaseTypedSqsFunction : SqsFunction<SqsBenchmarkMessage, UppercaseTypedSqsHandler>;
+
+public sealed class UppercaseTypedSqsHandler : ISqsMessageHandler<SqsBenchmarkMessage>
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SqsBenchmarkMessage message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _ = SqsWorkload.Execute(message);
+
+        return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+internal static class SqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsWorkload.Body
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -58,7 +58,7 @@ public sealed class UppercaseRawSqsHandler : ISqsRecordHandler
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body);
         _ = SqsWorkload.Execute(message);
 
         return ValueTask.FromResult(SqsRecordResult.Success);

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -58,7 +58,7 @@ public sealed class UppercaseRawSqsHandler : ISqsRecordHandler
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body);
+        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
         _ = SqsWorkload.Execute(message);
 
         return ValueTask.FromResult(SqsRecordResult.Success);

--- a/benchmarks/V6Target/V6Target.csproj
+++ b/benchmarks/V6Target/V6Target.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
     <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.Sqs\Kralizek.Lambda.Template.Sqs.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- add an SQS BenchmarkDotNet suite with batch sizes 1, 10, and 100
- compare direct AWS Lambda handling, published v5 typed SQS handling, current v6 raw SQS handling, and current v6 typed SQS handling
- keep the JSON payload and application workload equivalent across targets
- construct SQS envelopes outside the measured operation
- reuse the v5 isolated load context through a shared benchmark-host helper
- document how to run and interpret the SQS benchmark

## Method

Raw SDK and v6 raw handlers own JSON deserialization. V6 typed delegates the same JSON deserialization to the framework, while v5 uses its published typed SQS pipeline. Every target then applies the same uppercase workload to the decoded message.

The initial suite measures the all-success path only. Partial batch failure and nested-envelope scenarios remain separate follow-up benchmarks so the success-path results stay easy to interpret.

## Validation

The benchmark-validation workflow restores and builds the benchmark solution using the pinned .NET 10.0.400 SDK. Performance measurements remain local-only on controlled hardware.