### PR TITLE
Fix benchmark snapshot execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,3 +777,14 @@ jobs:
           ./artifacts/packages/*.snupkg
           --repo "${{ github.repository }}"
           --clobber
+
+  benchmark-snapshot:
+    name: Benchmark snapshot
+    needs: publish
+    if: needs.publish.result == 'success'
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/release-benchmarks.yml
+    with:
+      release-mode: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,11 +780,12 @@ jobs:
 
   benchmark-snapshot:
     name: Benchmark snapshot
-    needs: publish
+    needs: [publish, prepare-version]
     if: needs.publish.result == 'success'
     permissions:
       actions: read
       contents: write
     uses: ./.github/workflows/release-benchmarks.yml
     with:
-      release-mode: true
+      release-mode: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.release_channel != 'none') }}
+      release-tag: ${{ github.event_name == 'release' && github.event.release.tag_name || format('v{0}', needs.prepare-version.outputs.version) }}

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -1,9 +1,13 @@
-name: Release benchmark snapshot
+name: Benchmark snapshot
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  workflow_call:
+    inputs:
+      release-mode:
+        description: Resolve release metadata and attach the snapshot to an existing GitHub release when available
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
   pull_request:
     paths:
@@ -12,41 +16,19 @@ on:
 
 jobs:
   snapshot:
-    name: Collect release benchmarks
-    if: >-
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_repository.full_name == github.repository &&
-       (github.event.workflow_run.event == 'release' || github.event.workflow_run.event == 'workflow_dispatch')) ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request'
+    name: Collect benchmarks
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
     outputs:
       release-tag: ${{ steps.release-tag.outputs.tag }}
-      source-run-id: ${{ steps.source.outputs.run-id }}
 
     steps:
-      - name: Resolve source
-        id: source
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
-            echo "run-id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-            echo "run-id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout benchmark source
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.source.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Setup benchmark .NET
@@ -73,22 +55,19 @@ jobs:
       - name: Upload benchmark snapshot
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-results-${{ steps.source.outputs.run-id }}
+          name: benchmark-results-${{ github.run_id }}
           path: ${{ runner.temp }}/benchmark-results.zip
           if-no-files-found: error
 
       - name: Download release packages
-        if: github.event_name == 'workflow_run'
+        if: inputs.release-mode == true
         uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: ${{ runner.temp }}/packages
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Determine release tag
-        if: github.event_name == 'workflow_run'
+        if: inputs.release-mode == true
         id: release-tag
         shell: bash
         run: |
@@ -107,7 +86,7 @@ jobs:
 
   attach:
     name: Attach benchmark snapshot
-    if: github.event_name == 'workflow_run'
+    if: inputs.release-mode == true
     needs: snapshot
     runs-on: ubuntu-latest
     permissions:
@@ -118,7 +97,7 @@ jobs:
       - name: Download benchmark snapshot
         uses: actions/download-artifact@v8
         with:
-          name: benchmark-results-${{ needs.snapshot.outputs.source-run-id }}
+          name: benchmark-results-${{ github.run_id }}
           path: ${{ runner.temp }}/benchmark-release
 
       - name: Attach snapshot to GitHub release when available

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -4,26 +4,49 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'benchmarks/**'
+      - '.github/workflows/release-benchmarks.yml'
 
 jobs:
   snapshot:
     name: Collect release benchmarks
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      (github.event.workflow_run.event == 'release' || github.event.workflow_run.event == 'workflow_dispatch')
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       (github.event.workflow_run.event == 'release' || github.event.workflow_run.event == 'workflow_dispatch')) ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
     outputs:
       release-tag: ${{ steps.release-tag.outputs.tag }}
+      source-run-id: ${{ steps.source.outputs.run-id }}
 
     steps:
-      - name: Checkout release source
+      - name: Resolve source
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "run-id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "run-id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout benchmark source
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ steps.source.outputs.ref }}
           fetch-depth: 0
 
       - name: Setup benchmark .NET
@@ -50,11 +73,12 @@ jobs:
       - name: Upload benchmark snapshot
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-results-${{ github.event.workflow_run.id }}
+          name: benchmark-results-${{ steps.source.outputs.run-id }}
           path: ${{ runner.temp }}/benchmark-results.zip
           if-no-files-found: error
 
       - name: Download release packages
+        if: github.event_name == 'workflow_run'
         uses: actions/download-artifact@v8
         with:
           name: nuget-packages
@@ -64,6 +88,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Determine release tag
+        if: github.event_name == 'workflow_run'
         id: release-tag
         shell: bash
         run: |
@@ -82,6 +107,7 @@ jobs:
 
   attach:
     name: Attach benchmark snapshot
+    if: github.event_name == 'workflow_run'
     needs: snapshot
     runs-on: ubuntu-latest
     permissions:
@@ -92,7 +118,7 @@ jobs:
       - name: Download benchmark snapshot
         uses: actions/download-artifact@v8
         with:
-          name: benchmark-results-${{ github.event.workflow_run.id }}
+          name: benchmark-results-${{ needs.snapshot.outputs.source-run-id }}
           path: ${{ runner.temp }}/benchmark-release
 
       - name: Attach snapshot to GitHub release when available

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -4,10 +4,15 @@ on:
   workflow_call:
     inputs:
       release-mode:
-        description: Resolve release metadata and attach the snapshot to an existing GitHub release when available
+        description: Attach the snapshot to an existing GitHub release when available
         required: false
         type: boolean
         default: false
+      release-tag:
+        description: GitHub release tag used when release mode is enabled
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
 
 jobs:
@@ -17,8 +22,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    outputs:
-      release-tag: ${{ steps.release-tag.outputs.tag }}
 
     steps:
       - name: Checkout benchmark source
@@ -55,31 +58,6 @@ jobs:
           path: ${{ runner.temp }}/benchmark-results.zip
           if-no-files-found: error
 
-      - name: Download release packages
-        if: inputs.release-mode == true
-        uses: actions/download-artifact@v8
-        with:
-          name: nuget-packages
-          path: ${{ runner.temp }}/packages
-
-      - name: Determine release tag
-        if: inputs.release-mode == true
-        id: release-tag
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          package=$(ls "$RUNNER_TEMP"/packages/Kralizek.Lambda.Templates.*.nupkg)
-          nuspec=$(unzip -p "$package" '*.nuspec')
-          package_version=$(printf '%s\n' "$nuspec" | sed -n 's:.*<version>\(.*\)</version>.*:\1:p' | head -n 1)
-
-          if [[ ! "$package_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Package version is not a supported Semantic Versioning version: $package_version"
-            exit 1
-          fi
-
-          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
-
   attach:
     name: Attach benchmark snapshot
     if: inputs.release-mode == true
@@ -99,10 +77,15 @@ jobs:
       - name: Attach snapshot to GitHub release when available
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.snapshot.outputs.release-tag }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
         shell: bash
         run: |
           set -euo pipefail
+
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Release mode requires a release tag."
+            exit 1
+          fi
 
           if ! gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             echo "No GitHub release exists for $RELEASE_TAG; keeping the benchmark snapshot as a workflow artifact."

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -9,10 +9,6 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'benchmarks/**'
-      - '.github/workflows/release-benchmarks.yml'
 
 jobs:
   snapshot:
@@ -28,7 +24,7 @@ jobs:
       - name: Checkout benchmark source
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Setup benchmark .NET

--- a/benchmarks/BenchmarkRunner/BenchmarkCollector.cs
+++ b/benchmarks/BenchmarkRunner/BenchmarkCollector.cs
@@ -209,8 +209,7 @@ internal static class BenchmarkCollector
                 "--no-build",
                 "--",
                 "--filter", suite.Filter,
-                "--artifacts", artifactsDirectory,
-                "--exporters", "GitHub", "CSV", "HTML"
+                "--artifacts", artifactsDirectory
             ],
             context.BenchmarkRoot,
             cancellationToken);

--- a/benchmarks/Benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks/Benchmarks.csproj
@@ -13,12 +13,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
-    <ProjectReference Include="..\RawSdkTarget\RawSdkTarget.csproj" />
+    <ProjectReference Include="..\RawSdkTarget\RawSdkTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\V5Target\V5Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\V6Target\V6Target.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyMetadata Include="RawSdkTargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../RawSdkTarget/bin/$(Configuration)/net10.0/RawSdkTarget.dll'))" />
     <AssemblyMetadata Include="V5TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../V5Target/bin/$(Configuration)/net6.0/V5Target.dll'))" />
     <AssemblyMetadata Include="V6TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../V6Target/bin/$(Configuration)/net10.0/V6Target.dll'))" />
   </ItemGroup>

--- a/benchmarks/Benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks/Benchmarks.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
     <ProjectReference Include="..\RawSdkTarget\RawSdkTarget.csproj" />
     <ProjectReference Include="..\V6Target\V6Target.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
     <ProjectReference Include="..\V5Target\V5Target.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/benchmarks/Benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks/Benchmarks.csproj
@@ -14,13 +14,13 @@
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
     <ProjectReference Include="..\RawSdkTarget\RawSdkTarget.csproj" />
-    <ProjectReference Include="..\V6Target\V6Target.csproj" />
-    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
     <ProjectReference Include="..\V5Target\V5Target.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\V6Target\V6Target.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
     <AssemblyMetadata Include="V5TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../V5Target/bin/$(Configuration)/net6.0/V5Target.dll'))" />
+    <AssemblyMetadata Include="V6TargetAssemblyPath" Value="$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../V6Target/bin/$(Configuration)/net10.0/V6Target.dll'))" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -1,11 +1,9 @@
-using System.Linq;
-
 using BenchmarkDotNet.Running;
 
 var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
 return summaries.Any(summary =>
-    summary.HasCriticalValidationErrors ||
-    summary.Reports.Any(report => !report.Success))
+        summary.ValidationErrors.Any(error => error.IsCritical) ||
+        summary.Reports.Any(report => !report.Success))
     ? 1
     : 0;

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -2,10 +2,11 @@ using System.Linq;
 
 using BenchmarkDotNet.Running;
 
-var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args).ToArray();
 
-return summaries.Any(summary =>
-        summary.ValidationErrors.Any(error => error.IsCritical) ||
-        summary.Reports.Any(report => !report.Success))
+return summaries.Length == 0 ||
+       summaries.Any(summary =>
+           summary.ValidationErrors.Any(error => error.IsCritical) ||
+           summary.Reports.Any(report => !report.Success))
     ? 1
     : 0;

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -1,3 +1,11 @@
+using System.Linq;
+
 using BenchmarkDotNet.Running;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+return summaries.Any(summary =>
+    summary.HasCriticalValidationErrors ||
+    summary.Reports.Any(report => !report.Success))
+    ? 1
+    : 0;

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using BenchmarkDotNet.Running;
 
 var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -19,36 +19,30 @@ public class RequestBenchmarks
     private const string Input = "lambda benchmark";
 
     private readonly IRequestTarget _rawSdk = new RawSdkTarget.UppercaseTarget();
-    private readonly IRequestTarget _v6 = new V6Target.UppercaseTarget();
 
-    private V5TargetLoadContext? _v5LoadContext;
+    private TargetLoadContext? _v5LoadContext;
+    private TargetLoadContext? _v6LoadContext;
     private IRequestTarget? _v5;
+    private IRequestTarget? _v6;
 
     [GlobalSetup]
     public void Setup()
     {
-        var v5TargetAssemblyPath = typeof(RequestBenchmarks).Assembly
-            .GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Single(attribute => attribute.Key == "V5TargetAssemblyPath")
-            .Value;
-
-        if (string.IsNullOrWhiteSpace(v5TargetAssemblyPath) || !File.Exists(v5TargetAssemblyPath))
-        {
-            throw new FileNotFoundException("The V5 target assembly was not built.", v5TargetAssemblyPath);
-        }
-
-        _v5LoadContext = new V5TargetLoadContext(v5TargetAssemblyPath);
-        var assembly = _v5LoadContext.LoadFromAssemblyPath(v5TargetAssemblyPath);
-        var targetType = assembly.GetType("V5Target.UppercaseTarget", throwOnError: true)!;
-        _v5 = (IRequestTarget)Activator.CreateInstance(targetType)!;
+        (_v5LoadContext, _v5) = LoadTarget("V5TargetAssemblyPath", "V5Target.UppercaseTarget");
+        (_v6LoadContext, _v6) = LoadTarget("V6TargetAssemblyPath", "V6Target.UppercaseTarget");
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
         _v5 = null;
+        _v6 = null;
+
         _v5LoadContext?.Unload();
+        _v6LoadContext?.Unload();
+
         _v5LoadContext = null;
+        _v6LoadContext = null;
     }
 
     [Benchmark(Baseline = true)]
@@ -58,14 +52,36 @@ public class RequestBenchmarks
     public Task<string> V5() => _v5!.InvokeAsync(Input);
 
     [Benchmark]
-    public Task<string> V6() => _v6.InvokeAsync(Input);
+    public Task<string> V6() => _v6!.InvokeAsync(Input);
 
-    private sealed class V5TargetLoadContext : AssemblyLoadContext
+    private static (TargetLoadContext LoadContext, IRequestTarget Target) LoadTarget(
+        string metadataKey,
+        string targetTypeName)
+    {
+        var targetAssemblyPath = typeof(RequestBenchmarks).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == metadataKey)
+            .Value;
+
+        if (string.IsNullOrWhiteSpace(targetAssemblyPath) || !File.Exists(targetAssemblyPath))
+        {
+            throw new FileNotFoundException($"The benchmark target assembly for '{metadataKey}' was not built.", targetAssemblyPath);
+        }
+
+        var loadContext = new TargetLoadContext(targetAssemblyPath);
+        var assembly = loadContext.LoadFromAssemblyPath(targetAssemblyPath);
+        var targetType = assembly.GetType(targetTypeName, throwOnError: true)!;
+        var target = (IRequestTarget)Activator.CreateInstance(targetType)!;
+
+        return (loadContext, target);
+    }
+
+    private sealed class TargetLoadContext : AssemblyLoadContext
     {
         private readonly AssemblyDependencyResolver _resolver;
 
-        public V5TargetLoadContext(string targetAssemblyPath)
-            : base(nameof(V5TargetLoadContext), isCollectible: true)
+        public TargetLoadContext(string targetAssemblyPath)
+            : base(isCollectible: true)
         {
             _resolver = new AssemblyDependencyResolver(targetAssemblyPath);
         }

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -18,16 +18,17 @@ public class RequestBenchmarks
 {
     private const string Input = "lambda benchmark";
 
-    private readonly IRequestTarget _rawSdk = new RawSdkTarget.UppercaseTarget();
-
+    private TargetLoadContext? _rawSdkLoadContext;
     private TargetLoadContext? _v5LoadContext;
     private TargetLoadContext? _v6LoadContext;
+    private IRequestTarget? _rawSdk;
     private IRequestTarget? _v5;
     private IRequestTarget? _v6;
 
     [GlobalSetup]
     public void Setup()
     {
+        (_rawSdkLoadContext, _rawSdk) = LoadTarget("RawSdkTargetAssemblyPath", "RawSdkTarget.UppercaseTarget");
         (_v5LoadContext, _v5) = LoadTarget("V5TargetAssemblyPath", "V5Target.UppercaseTarget");
         (_v6LoadContext, _v6) = LoadTarget("V6TargetAssemblyPath", "V6Target.UppercaseTarget");
     }
@@ -35,18 +36,21 @@ public class RequestBenchmarks
     [GlobalCleanup]
     public void Cleanup()
     {
+        _rawSdk = null;
         _v5 = null;
         _v6 = null;
 
+        _rawSdkLoadContext?.Unload();
         _v5LoadContext?.Unload();
         _v6LoadContext?.Unload();
 
+        _rawSdkLoadContext = null;
         _v5LoadContext = null;
         _v6LoadContext = null;
     }
 
     [Benchmark(Baseline = true)]
-    public Task<string> RawSdk() => _rawSdk.InvokeAsync(Input);
+    public Task<string> RawSdk() => _rawSdk!.InvokeAsync(Input);
 
     [Benchmark]
     public Task<string> V5() => _v5!.InvokeAsync(Input);

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -68,7 +68,7 @@ public class RequestBenchmarks
             throw new FileNotFoundException($"The benchmark target assembly for '{metadataKey}' was not built.", targetAssemblyPath);
         }
 
-        var loadContext = new TargetLoadContext(targetAssemblyPath);
+        var loadContext = new TargetLoadContext(targetAssemblyPath, targetTypeName);
         var assembly = loadContext.LoadFromAssemblyPath(targetAssemblyPath);
         var targetType = assembly.GetType(targetTypeName, throwOnError: true)!;
         var target = (IRequestTarget)Activator.CreateInstance(targetType)!;
@@ -80,8 +80,8 @@ public class RequestBenchmarks
     {
         private readonly AssemblyDependencyResolver _resolver;
 
-        public TargetLoadContext(string targetAssemblyPath)
-            : base(isCollectible: true)
+        public TargetLoadContext(string targetAssemblyPath, string name)
+            : base(name, isCollectible: true)
         {
             _resolver = new AssemblyDependencyResolver(targetAssemblyPath);
         }

--- a/benchmarks/RawSdkTarget/RawSdkTarget.csproj
+++ b/benchmarks/RawSdkTarget/RawSdkTarget.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/V6Target/V6Target.csproj
+++ b/benchmarks/V6Target/V6Target.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- make the benchmark host return a non-zero exit code when BenchmarkDotNet reports no summaries, critical validation errors, or unsuccessful benchmark reports
- load the raw SDK, v5, and v6 benchmark targets through separate collectible `AssemblyLoadContext` instances behind the neutral `BenchmarkWorkloads` contract
- keep target projects as build dependencies without referencing their output assemblies from the BenchmarkDotNet host
- copy each target's runtime dependency closure so `AssemblyDependencyResolver` can resolve target-specific dependencies reliably
- make benchmark snapshots manually runnable through `workflow_dispatch`
- expose the snapshot workflow through `workflow_call` and run it from CI only after the `publish` job succeeds
- pass the release tag from the calling CI workflow instead of re-reading package metadata in the benchmark workflow
- avoid duplicate BenchmarkDotNet exporter configuration while retaining GitHub Markdown, CSV, and HTML reports

## Context

The alpha dry-run release snapshot completed mechanically but contained only `NA` results. BenchmarkDotNet's generated process could not resolve the v6 runtime assembly and the benchmark host still exited successfully because reports were generated despite all benchmark cases failing.

The benchmark host now treats every implementation under test consistently. Raw SDK, v5, and v6 are loaded as isolated targets, while the neutral workload contract remains in the default load context. Each target output carries the dependency files required by `AssemblyDependencyResolver`, so the generated BenchmarkDotNet process can resolve each target independently.

The snapshot workflow is reusable and manually runnable. CI invokes it only after a successful `publish` job, so ordinary pull-request and push CI runs do not collect benchmark snapshots. When a real release exists, the caller passes its tag directly to the reusable workflow for attachment. Dry runs and manual package builds remain artifact-only and do not try to discover or attach to a release.

## Validation

- CI passes
- benchmark validation builds the benchmark solution on the pinned .NET 10.0.400 SDK
- the generated BenchmarkDotNet process successfully executes raw SDK, v5, and v6 targets through isolated load contexts
- invalid BenchmarkDotNet executions, including filters that produce no summaries, return a non-zero exit code instead of producing an accepted snapshot
- successful snapshot runs produce GitHub Markdown, CSV, and HTML reports without duplicate-exporter warnings
- snapshot artifacts are packaged and uploaded successfully