### PR TITLE
Publish benchmark history on master

### DIFF
--- a/.github/workflows/benchmark-history.yml
+++ b/.github/workflows/benchmark-history.yml
@@ -1,0 +1,21 @@
+name: Benchmark history
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-history-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Run and publish benchmarks
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/release-benchmarks.yml
+    with:
+      publish-history: true
+      release-mode: false

--- a/.github/workflows/benchmark-history.yml
+++ b/.github/workflows/benchmark-history.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: benchmark-history-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   benchmark:

--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -1,10 +1,6 @@
 name: Benchmark validation
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - 'benchmarks/**'
   pull_request:
     paths:
       - 'benchmarks/**'
@@ -22,4 +18,5 @@ jobs:
       contents: read
     uses: ./.github/workflows/release-benchmarks.yml
     with:
+      publish-history: false
       release-mode: false

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -3,8 +3,13 @@ name: Benchmark snapshot
 on:
   workflow_call:
     inputs:
+      publish-history:
+        description: Publish benchmark history to the configured results branch
+        required: false
+        type: boolean
+        default: false
       release-mode:
-        description: Publish benchmark history and attach the snapshot to an existing GitHub release
+        description: Attach the benchmark snapshot to an existing GitHub release
         required: false
         type: boolean
         default: false
@@ -55,7 +60,7 @@ jobs:
 
   publish-history:
     name: Publish benchmark history
-    if: inputs.release-mode == true
+    if: inputs.publish-history == true
     needs: snapshot
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- publish BenchmarkDotNet history for every push to `master`
- keep raw BenchmarkDotNet artifacts for those runs
- keep PR benchmark validation limited to changes under `benchmarks/**`
- separate benchmark history publication from release snapshot attachment
- preserve the existing release flow so snapshots are attached only for real, non-dry releases

## Why

Benchmark history is most useful when it reflects the sequence of commits that actually land on `master`, rather than only release runs. The reusable benchmark workflow already performs the expensive part, so this change makes publication an independent opt-in while keeping release attachment separate.

The existing `release-mode` input remains backward-compatible for the CI release caller, but now controls only release attachment. A new `publish-history` input controls the Martin Costello results publisher.

## Behavior

- PR touching `benchmarks/**`: run benchmarks for validation only
- push to `master`: run benchmarks, upload raw artifacts, publish summarized history
- dry-run release: run benchmarks and upload artifacts, but do not publish history or attach to a release
- real release: run benchmarks, upload artifacts, and attach the snapshot to the release

This also avoids running both benchmark validation and benchmark history for benchmark-only pushes to `master`.