### PR TITLE
Optimize V6 SQS context allocations

### DIFF
--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -85,6 +85,7 @@ public abstract class FunctionContext
     /// </summary>
     public IReadOnlyDictionary<string, object?> Properties { get; }
 
+#pragma warning disable S3267 // Explicit loops avoid LINQ iterator allocations on this per-record hot path.
     private sealed class PropertyOverlay(
         IReadOnlyDictionary<string, object?> source,
         string propertyName,
@@ -158,6 +159,7 @@ public abstract class FunctionContext
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+#pragma warning restore S3267
 }
 
 /// <summary>

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -44,6 +45,25 @@ public abstract class FunctionContext
         Properties = new ReadOnlyDictionary<string, object?>(propertySnapshot);
     }
 
+    protected FunctionContext(
+        FunctionContext source,
+        string propertyName,
+        object? propertyValue)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(propertyName);
+
+        AwsRequestId = source.AwsRequestId;
+        FunctionName = source.FunctionName;
+        FunctionVersion = source.FunctionVersion;
+        InvokedFunctionArn = source.InvokedFunctionArn;
+        MemoryLimitInMB = source.MemoryLimitInMB;
+        RemainingTime = source.RemainingTime;
+        LogGroupName = source.LogGroupName;
+        LogStreamName = source.LogStreamName;
+        Properties = new PropertyOverlay(source.Properties, propertyName, propertyValue);
+    }
+
     public string AwsRequestId { get; }
 
     public string FunctionName { get; }
@@ -64,6 +84,80 @@ public abstract class FunctionContext
     /// Gets additional runtime-specific data that is not represented by the strongly typed properties.
     /// </summary>
     public IReadOnlyDictionary<string, object?> Properties { get; }
+
+    private sealed class PropertyOverlay(
+        IReadOnlyDictionary<string, object?> source,
+        string propertyName,
+        object? propertyValue) : IReadOnlyDictionary<string, object?>
+    {
+        public int Count => source.ContainsKey(propertyName) ? source.Count : source.Count + 1;
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                foreach (var key in source.Keys)
+                {
+                    if (!string.Equals(key, propertyName, StringComparison.Ordinal))
+                    {
+                        yield return key;
+                    }
+                }
+
+                yield return propertyName;
+            }
+        }
+
+        public IEnumerable<object?> Values
+        {
+            get
+            {
+                foreach (var pair in source)
+                {
+                    if (!string.Equals(pair.Key, propertyName, StringComparison.Ordinal))
+                    {
+                        yield return pair.Value;
+                    }
+                }
+
+                yield return propertyValue;
+            }
+        }
+
+        public object? this[string key]
+            => string.Equals(key, propertyName, StringComparison.Ordinal)
+                ? propertyValue
+                : source[key];
+
+        public bool ContainsKey(string key)
+            => string.Equals(key, propertyName, StringComparison.Ordinal) || source.ContainsKey(key);
+
+        public bool TryGetValue(string key, out object? value)
+        {
+            if (string.Equals(key, propertyName, StringComparison.Ordinal))
+            {
+                value = propertyValue;
+                return true;
+            }
+
+            return source.TryGetValue(key, out value);
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            foreach (var pair in source)
+            {
+                if (!string.Equals(pair.Key, propertyName, StringComparison.Ordinal))
+                {
+                    yield return pair;
+                }
+            }
+
+            yield return new KeyValuePair<string, object?>(propertyName, propertyValue);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 }
 
 /// <summary>
@@ -97,4 +191,10 @@ public class RecordContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
+
+    protected RecordContext(
+        RecordContext source,
+        string propertyName,
+        object? propertyValue)
+        : base(source, propertyName, propertyValue) { }
 }

--- a/src/Kralizek.Lambda.Template.Sqs/SqsMessageContext.cs
+++ b/src/Kralizek.Lambda.Template.Sqs/SqsMessageContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 using Amazon.Lambda.SQSEvents;
 
@@ -10,19 +11,24 @@ namespace Kralizek.Lambda;
 /// </summary>
 public sealed class SqsMessageContext : RecordContext
 {
+    private static readonly IReadOnlyDictionary<string, string> EmptyAttributes =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
+    private static readonly IReadOnlyDictionary<string, SQSEvent.MessageAttribute> EmptyMessageAttributes =
+        new ReadOnlyDictionary<string, SQSEvent.MessageAttribute>(new Dictionary<string, SQSEvent.MessageAttribute>());
+
     private SqsMessageContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
+        RecordContext invocationContext,
         SQSEvent.SQSMessage record)
-        : base(metadata, properties)
+        : base(invocationContext, SqsMessageContextExtensions.SqsMessagePropertyName, record)
     {
         MessageId = record.MessageId;
         ReceiptHandle = record.ReceiptHandle;
         Attributes = record.Attributes is null
-            ? new Dictionary<string, string>()
+            ? EmptyAttributes
             : new Dictionary<string, string>(record.Attributes);
         MessageAttributes = record.MessageAttributes is null
-            ? new Dictionary<string, SQSEvent.MessageAttribute>()
+            ? EmptyMessageAttributes
             : new Dictionary<string, SQSEvent.MessageAttribute>(record.MessageAttributes);
         EventSource = record.EventSource;
         EventSourceArn = record.EventSourceArn;
@@ -69,22 +75,7 @@ public sealed class SqsMessageContext : RecordContext
         ArgumentNullException.ThrowIfNull(invocationContext);
         ArgumentNullException.ThrowIfNull(record);
 
-        var metadata = new FunctionContextMetadata(
-            invocationContext.AwsRequestId,
-            invocationContext.FunctionName,
-            invocationContext.FunctionVersion,
-            invocationContext.InvokedFunctionArn,
-            invocationContext.MemoryLimitInMB,
-            invocationContext.RemainingTime,
-            invocationContext.LogGroupName,
-            invocationContext.LogStreamName);
-
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [SqsMessageContextExtensions.SqsMessagePropertyName] = record
-        };
-
-        return new SqsMessageContext(metadata, properties, record);
+        return new SqsMessageContext(invocationContext, record);
     }
 }
 

--- a/tests/Tests.Lambda.Template/FunctionContextTests.cs
+++ b/tests/Tests.Lambda.Template/FunctionContextTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 using Kralizek.Lambda;
 
@@ -63,6 +64,51 @@ public class FunctionContextTests
         });
     }
 
+    [Test]
+    public void Derived_context_overlay_exposes_new_property_and_preserves_existing_properties()
+    {
+        var lambdaContext = TestLambdaContexts.Create();
+        var metadata = FunctionContextFactory.CreateMetadata(lambdaContext);
+        var properties = FunctionContextFactory.CreateProperties(lambdaContext);
+        properties["Source"] = "SQS";
+
+        var source = new SpecializedRecordContext(metadata, properties);
+        var context = new OverlaidRecordContext(source, "Record", 42);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Properties["Record"], Is.EqualTo(42));
+            Assert.That(context.Properties.TryGetValue("Record", out var record), Is.True);
+            Assert.That(record, Is.EqualTo(42));
+            Assert.That(context.Properties["Source"], Is.EqualTo("SQS"));
+            Assert.That(context.GetLambdaContext(), Is.SameAs(lambdaContext));
+        });
+    }
+
+    [Test]
+    public void Derived_context_overlay_replaces_existing_property_without_duplicating_it()
+    {
+        var lambdaContext = TestLambdaContexts.Create();
+        var metadata = FunctionContextFactory.CreateMetadata(lambdaContext);
+        var properties = FunctionContextFactory.CreateProperties(lambdaContext);
+        properties["Source"] = "SQS";
+        properties["Other"] = 42;
+
+        var source = new SpecializedRecordContext(metadata, properties);
+        var context = new OverlaidRecordContext(source, "Source", "Overlaid");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Properties.Count, Is.EqualTo(source.Properties.Count));
+            Assert.That(context.Properties["Source"], Is.EqualTo("Overlaid"));
+            Assert.That(context.Properties.TryGetValue("Source", out var sourceValue), Is.True);
+            Assert.That(sourceValue, Is.EqualTo("Overlaid"));
+            Assert.That(context.Properties["Other"], Is.EqualTo(42));
+            Assert.That(context.Properties.Keys.Count(key => key == "Source"), Is.EqualTo(1));
+            Assert.That(context.Properties.Count(pair => pair.Key == "Source"), Is.EqualTo(1));
+        });
+    }
+
     private sealed class SpecializedEventContext : EventContext
     {
         public SpecializedEventContext(
@@ -85,5 +131,14 @@ public class FunctionContextTests
             FunctionContextMetadata metadata,
             IReadOnlyDictionary<string, object?> properties)
             : base(metadata, properties) { }
+    }
+
+    private sealed class OverlaidRecordContext : RecordContext
+    {
+        public OverlaidRecordContext(
+            RecordContext source,
+            string propertyName,
+            object? propertyValue)
+            : base(source, propertyName, propertyValue) { }
     }
 }


### PR DESCRIPTION
## What changed

- Added an immutable property-overlay path for derived record contexts so source-specific contexts can reuse invocation properties without cloning the full dictionary.
- Updated `SqsMessageContext` to reuse invocation metadata/state instead of recreating `FunctionContextMetadata` and copying the invocation property bag per record.
- Reused shared read-only empty dictionaries when an SQS record has no system or message attributes.

## Why

The V6 performance investigation identified `SqsMessageContext.Create` as the largest avoidable per-record allocation source. The current implementation copied invocation metadata and properties for every SQS record, then `FunctionContext` copied that property dictionary again. Allocation traces also showed two empty SQS dictionaries per record when attributes were absent.

This change keeps the V6 semantics intact: contexts remain read-only, invocation properties remain immutable to consumers, the original raw SQS record is still available through `GetSqsMessage()`, and per-record DI scope behavior is unchanged.

## Validation

The existing investigation and end-to-end benchmark infrastructure is intentionally preserved. CI should validate behavior; the local performance agent can run the focused decomposition and Raw/V5/V6 benchmark suite to attach before/after numbers to this PR before it is marked ready for review.