### PR TITLE
Publish benchmarks to dedicated history branch

### DIFF
--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -103,7 +103,7 @@ jobs:
           cd "$RUNNER_TEMP"
           zip -r benchmark-results.zip BenchmarkDotNet.Artifacts
 
-      - name: Attach benchmark snapshot
+      - name: Attach snapshot to GitHub release when available
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release-tag }}

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Publish benchmark history
         uses: martincostello/benchmarkdotnet-results-publisher@b8fe7bb9691c4fdcda7dee630aa09493e81004b8 # v2
         with:
+          branch: benchmark-history
           results-path: ${{ runner.temp }}/BenchmarkDotNet.Artifacts
 
   attach:
@@ -102,7 +103,7 @@ jobs:
           cd "$RUNNER_TEMP"
           zip -r benchmark-results.zip BenchmarkDotNet.Artifacts
 
-      - name: Attach snapshot to GitHub release when available
+      - name: Attach benchmark snapshot
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release-tag }}


### PR DESCRIPTION
## Summary

- publish BenchmarkDotNet history to `benchmark-history` instead of the default `gh-pages` branch
- keep `gh-pages` available for future GitHub Pages/Jekyll content
- preserve the existing benchmark `data.json` history on the new orphan branch

## Validation

- confirmed `martincostello/benchmarkdotnet-results-publisher` supports the `branch` input
- verified the workflow diff is a single added line: `branch: benchmark-history`
- verified `benchmark-history` contains the benchmark data and is disconnected from the source branch history