### PR TITLE
Optimize record context allocations across event sources

### DIFF
--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -363,5 +363,6 @@ public class RecordContext : FunctionContext
             firstPropertyName,
             firstPropertyValue,
             secondPropertyName,
-            secondPropertyValue) { }
+            secondPropertyValue)
+    { }
 }

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -49,9 +49,30 @@ public abstract class FunctionContext
         FunctionContext source,
         string propertyName,
         object? propertyValue)
+        : this(source, CreatePropertyOverlay(source, propertyName, propertyValue))
+    {
+    }
+
+    protected FunctionContext(
+        FunctionContext source,
+        string firstPropertyName,
+        object? firstPropertyValue,
+        string secondPropertyName,
+        object? secondPropertyValue)
+        : this(
+            source,
+            CreatePropertyOverlay(
+                source,
+                firstPropertyName,
+                firstPropertyValue,
+                secondPropertyName,
+                secondPropertyValue))
+    {
+    }
+
+    private FunctionContext(FunctionContext source, IReadOnlyDictionary<string, object?> properties)
     {
         ArgumentNullException.ThrowIfNull(source);
-        ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
         AwsRequestId = source.AwsRequestId;
         FunctionName = source.FunctionName;
@@ -61,7 +82,7 @@ public abstract class FunctionContext
         RemainingTime = source.RemainingTime;
         LogGroupName = source.LogGroupName;
         LogStreamName = source.LogStreamName;
-        Properties = new PropertyOverlay(source.Properties, propertyName, propertyValue);
+        Properties = properties;
     }
 
     public string AwsRequestId { get; }
@@ -85,27 +106,110 @@ public abstract class FunctionContext
     /// </summary>
     public IReadOnlyDictionary<string, object?> Properties { get; }
 
-#pragma warning disable S3267 // Explicit loops avoid LINQ iterator allocations on this per-record hot path.
-    private sealed class PropertyOverlay(
-        IReadOnlyDictionary<string, object?> source,
+    private static IReadOnlyDictionary<string, object?> CreatePropertyOverlay(
+        FunctionContext source,
         string propertyName,
-        object? propertyValue) : IReadOnlyDictionary<string, object?>
+        object? propertyValue)
     {
-        public int Count => source.ContainsKey(propertyName) ? source.Count : source.Count + 1;
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(propertyName);
+
+        return new PropertyOverlay(source.Properties, propertyName, propertyValue);
+    }
+
+    private static IReadOnlyDictionary<string, object?> CreatePropertyOverlay(
+        FunctionContext source,
+        string firstPropertyName,
+        object? firstPropertyValue,
+        string secondPropertyName,
+        object? secondPropertyValue)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(firstPropertyName);
+        ArgumentException.ThrowIfNullOrEmpty(secondPropertyName);
+
+        return new PropertyOverlay(
+            source.Properties,
+            firstPropertyName,
+            firstPropertyValue,
+            secondPropertyName,
+            secondPropertyValue);
+    }
+
+#pragma warning disable S3267 // Explicit loops avoid LINQ iterator allocations on this per-record hot path.
+    private sealed class PropertyOverlay : IReadOnlyDictionary<string, object?>
+    {
+        private readonly IReadOnlyDictionary<string, object?> _source;
+        private readonly string _firstPropertyName;
+        private readonly object? _firstPropertyValue;
+        private readonly string? _secondPropertyName;
+        private readonly object? _secondPropertyValue;
+
+        public PropertyOverlay(
+            IReadOnlyDictionary<string, object?> source,
+            string propertyName,
+            object? propertyValue)
+        {
+            _source = source;
+            _firstPropertyName = propertyName;
+            _firstPropertyValue = propertyValue;
+        }
+
+        public PropertyOverlay(
+            IReadOnlyDictionary<string, object?> source,
+            string firstPropertyName,
+            object? firstPropertyValue,
+            string secondPropertyName,
+            object? secondPropertyValue)
+        {
+            _source = source;
+            _firstPropertyName = firstPropertyName;
+            _firstPropertyValue = firstPropertyValue;
+            _secondPropertyName = secondPropertyName;
+            _secondPropertyValue = secondPropertyValue;
+        }
+
+        public int Count
+        {
+            get
+            {
+                var count = _source.Count;
+
+                if (!_source.ContainsKey(_firstPropertyName))
+                {
+                    count++;
+                }
+
+                if (_secondPropertyName is not null
+                    && !string.Equals(_secondPropertyName, _firstPropertyName, StringComparison.Ordinal)
+                    && !_source.ContainsKey(_secondPropertyName))
+                {
+                    count++;
+                }
+
+                return count;
+            }
+        }
 
         public IEnumerable<string> Keys
         {
             get
             {
-                foreach (var key in source.Keys)
+                foreach (var key in _source.Keys)
                 {
-                    if (!string.Equals(key, propertyName, StringComparison.Ordinal))
+                    if (!IsOverlayKey(key))
                     {
                         yield return key;
                     }
                 }
 
-                yield return propertyName;
+                yield return _firstPropertyName;
+
+                if (_secondPropertyName is not null
+                    && !string.Equals(_secondPropertyName, _firstPropertyName, StringComparison.Ordinal))
+                {
+                    yield return _secondPropertyName;
+                }
             }
         }
 
@@ -113,51 +217,99 @@ public abstract class FunctionContext
         {
             get
             {
-                foreach (var pair in source)
+                foreach (var pair in _source)
                 {
-                    if (!string.Equals(pair.Key, propertyName, StringComparison.Ordinal))
+                    if (!IsOverlayKey(pair.Key))
                     {
                         yield return pair.Value;
                     }
                 }
 
-                yield return propertyValue;
+                yield return GetOverlayValue(_firstPropertyName);
+
+                if (_secondPropertyName is not null
+                    && !string.Equals(_secondPropertyName, _firstPropertyName, StringComparison.Ordinal))
+                {
+                    yield return _secondPropertyValue;
+                }
             }
         }
 
         public object? this[string key]
-            => string.Equals(key, propertyName, StringComparison.Ordinal)
-                ? propertyValue
-                : source[key];
+        {
+            get
+            {
+                if (TryGetOverlayValue(key, out var value))
+                {
+                    return value;
+                }
 
-        public bool ContainsKey(string key)
-            => string.Equals(key, propertyName, StringComparison.Ordinal) || source.ContainsKey(key);
+                return _source[key];
+            }
+        }
+
+        public bool ContainsKey(string key) => IsOverlayKey(key) || _source.ContainsKey(key);
 
         public bool TryGetValue(string key, out object? value)
         {
-            if (string.Equals(key, propertyName, StringComparison.Ordinal))
+            if (TryGetOverlayValue(key, out value))
             {
-                value = propertyValue;
                 return true;
             }
 
-            return source.TryGetValue(key, out value);
+            return _source.TryGetValue(key, out value);
         }
 
         public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
         {
-            foreach (var pair in source)
+            foreach (var pair in _source)
             {
-                if (!string.Equals(pair.Key, propertyName, StringComparison.Ordinal))
+                if (!IsOverlayKey(pair.Key))
                 {
                     yield return pair;
                 }
             }
 
-            yield return new KeyValuePair<string, object?>(propertyName, propertyValue);
+            yield return new KeyValuePair<string, object?>(_firstPropertyName, GetOverlayValue(_firstPropertyName));
+
+            if (_secondPropertyName is not null
+                && !string.Equals(_secondPropertyName, _firstPropertyName, StringComparison.Ordinal))
+            {
+                yield return new KeyValuePair<string, object?>(_secondPropertyName, _secondPropertyValue);
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private bool IsOverlayKey(string key)
+            => string.Equals(key, _firstPropertyName, StringComparison.Ordinal)
+                || (_secondPropertyName is not null
+                    && string.Equals(key, _secondPropertyName, StringComparison.Ordinal));
+
+        private object? GetOverlayValue(string key)
+            => _secondPropertyName is not null
+                && string.Equals(key, _secondPropertyName, StringComparison.Ordinal)
+                    ? _secondPropertyValue
+                    : _firstPropertyValue;
+
+        private bool TryGetOverlayValue(string key, out object? value)
+        {
+            if (_secondPropertyName is not null
+                && string.Equals(key, _secondPropertyName, StringComparison.Ordinal))
+            {
+                value = _secondPropertyValue;
+                return true;
+            }
+
+            if (string.Equals(key, _firstPropertyName, StringComparison.Ordinal))
+            {
+                value = _firstPropertyValue;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
     }
 #pragma warning restore S3267
 }
@@ -199,4 +351,17 @@ public class RecordContext : FunctionContext
         string propertyName,
         object? propertyValue)
         : base(source, propertyName, propertyValue) { }
+
+    protected RecordContext(
+        RecordContext source,
+        string firstPropertyName,
+        object? firstPropertyValue,
+        string secondPropertyName,
+        object? secondPropertyValue)
+        : base(
+            source,
+            firstPropertyName,
+            firstPropertyValue,
+            secondPropertyName,
+            secondPropertyValue) { }
 }

--- a/src/Kralizek.Lambda.Template.DynamoDbStreams/DynamoDbStreamRecordContext.cs
+++ b/src/Kralizek.Lambda.Template.DynamoDbStreams/DynamoDbStreamRecordContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 using Amazon.Lambda.DynamoDBEvents;
 
@@ -11,10 +10,9 @@ namespace Kralizek.Lambda;
 public sealed class DynamoDbStreamRecordContext : RecordContext
 {
     private DynamoDbStreamRecordContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
+        RecordContext invocationContext,
         DynamoDBEvent.DynamodbStreamRecord record)
-        : base(metadata, properties)
+        : base(invocationContext, DynamoDbStreamRecordContextExtensions.DynamoDbStreamRecordPropertyName, record)
     {
         EventId = record.EventID;
         EventName = record.EventName;
@@ -40,22 +38,7 @@ public sealed class DynamoDbStreamRecordContext : RecordContext
         ArgumentNullException.ThrowIfNull(invocationContext);
         ArgumentNullException.ThrowIfNull(record);
 
-        var metadata = new FunctionContextMetadata(
-            invocationContext.AwsRequestId,
-            invocationContext.FunctionName,
-            invocationContext.FunctionVersion,
-            invocationContext.InvokedFunctionArn,
-            invocationContext.MemoryLimitInMB,
-            invocationContext.RemainingTime,
-            invocationContext.LogGroupName,
-            invocationContext.LogStreamName);
-
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [DynamoDbStreamRecordContextExtensions.DynamoDbStreamRecordPropertyName] = record
-        };
-
-        return new DynamoDbStreamRecordContext(metadata, properties, record);
+        return new DynamoDbStreamRecordContext(invocationContext, record);
     }
 }
 

--- a/src/Kralizek.Lambda.Template.KinesisStreams/KinesisStreamRecordContext.cs
+++ b/src/Kralizek.Lambda.Template.KinesisStreams/KinesisStreamRecordContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 using Amazon.Lambda.KinesisEvents;
 
@@ -11,10 +10,9 @@ namespace Kralizek.Lambda;
 public sealed class KinesisStreamRecordContext : RecordContext
 {
     private KinesisStreamRecordContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
+        RecordContext invocationContext,
         KinesisEvent.KinesisEventRecord record)
-        : base(metadata, properties)
+        : base(invocationContext, KinesisStreamRecordContextExtensions.KinesisRecordPropertyName, record)
     {
         SequenceNumber = record.Kinesis?.SequenceNumber;
         PartitionKey = record.Kinesis?.PartitionKey;
@@ -32,22 +30,7 @@ public sealed class KinesisStreamRecordContext : RecordContext
         ArgumentNullException.ThrowIfNull(invocationContext);
         ArgumentNullException.ThrowIfNull(record);
 
-        var metadata = new FunctionContextMetadata(
-            invocationContext.AwsRequestId,
-            invocationContext.FunctionName,
-            invocationContext.FunctionVersion,
-            invocationContext.InvokedFunctionArn,
-            invocationContext.MemoryLimitInMB,
-            invocationContext.RemainingTime,
-            invocationContext.LogGroupName,
-            invocationContext.LogStreamName);
-
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [KinesisStreamRecordContextExtensions.KinesisRecordPropertyName] = record
-        };
-
-        return new KinesisStreamRecordContext(metadata, properties, record);
+        return new KinesisStreamRecordContext(invocationContext, record);
     }
 }
 

--- a/src/Kralizek.Lambda.Template.S3/S3Contexts.cs
+++ b/src/Kralizek.Lambda.Template.S3/S3Contexts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 using Amazon.Lambda.S3Events;
 
@@ -7,8 +8,10 @@ namespace Kralizek.Lambda;
 
 public sealed class S3RecordContext : RecordContext
 {
-    private S3RecordContext(FunctionContextMetadata metadata, IReadOnlyDictionary<string, object?> properties)
-        : base(metadata, properties)
+    private S3RecordContext(
+        RecordContext invocationContext,
+        S3Event.S3EventNotificationRecord record)
+        : base(invocationContext, S3RecordContextExtensions.S3RecordPropertyName, record)
     {
     }
 
@@ -17,25 +20,8 @@ public sealed class S3RecordContext : RecordContext
         ArgumentNullException.ThrowIfNull(invocationContext);
         ArgumentNullException.ThrowIfNull(record);
 
-        var metadata = CopyMetadata(invocationContext);
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [S3RecordContextExtensions.S3RecordPropertyName] = record
-        };
-
-        return new S3RecordContext(metadata, properties);
+        return new S3RecordContext(invocationContext, record);
     }
-
-    internal static FunctionContextMetadata CopyMetadata(RecordContext context) =>
-        new(
-            context.AwsRequestId,
-            context.FunctionName,
-            context.FunctionVersion,
-            context.InvokedFunctionArn,
-            context.MemoryLimitInMB,
-            context.RemainingTime,
-            context.LogGroupName,
-            context.LogStreamName);
 }
 
 public static class S3RecordContextExtensions
@@ -57,18 +43,25 @@ public static class S3RecordContextExtensions
 
 public sealed class S3BatchContext : RecordContext
 {
+    private static readonly IReadOnlyDictionary<string, string> EmptyUserArguments =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
     private S3BatchContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
+        RecordContext invocationContext,
         S3BatchEvent request,
         S3BatchTask task)
-        : base(metadata, properties)
+        : base(
+            invocationContext,
+            S3BatchContextExtensions.S3BatchRequestPropertyName,
+            request,
+            S3BatchContextExtensions.S3BatchTaskPropertyName,
+            task)
     {
         InvocationId = request.InvocationId ?? string.Empty;
         JobId = request.Job?.Id ?? string.Empty;
         TaskId = task.TaskId ?? string.Empty;
         UserArguments = request.Job?.UserArguments is null
-            ? new Dictionary<string, string>()
+            ? EmptyUserArguments
             : new Dictionary<string, string>(request.Job.UserArguments);
     }
 
@@ -83,13 +76,8 @@ public sealed class S3BatchContext : RecordContext
         ArgumentNullException.ThrowIfNull(task);
 
         var request = task.Request ?? throw new InvalidOperationException("The S3 Batch task is not associated with its invocation request.");
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [S3BatchContextExtensions.S3BatchRequestPropertyName] = request,
-            [S3BatchContextExtensions.S3BatchTaskPropertyName] = task
-        };
 
-        return new S3BatchContext(S3RecordContext.CopyMetadata(invocationContext), properties, request, task);
+        return new S3BatchContext(invocationContext, request, task);
     }
 }
 

--- a/src/Kralizek.Lambda.Template.Sns/SnsNotificationContext.cs
+++ b/src/Kralizek.Lambda.Template.Sns/SnsNotificationContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 using Amazon.Lambda.SNSEvents;
 
@@ -10,11 +11,13 @@ namespace Kralizek.Lambda;
 /// </summary>
 public sealed class SnsNotificationContext : RecordContext
 {
+    private static readonly IReadOnlyDictionary<string, SNSEvent.MessageAttribute> EmptyMessageAttributes =
+        new ReadOnlyDictionary<string, SNSEvent.MessageAttribute>(new Dictionary<string, SNSEvent.MessageAttribute>());
+
     private SnsNotificationContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
+        RecordContext invocationContext,
         SNSEvent.SNSRecord record)
-        : base(metadata, properties)
+        : base(invocationContext, SnsNotificationContextExtensions.SnsRecordPropertyName, record)
     {
         var message = record.Sns ?? throw new InvalidOperationException("The SNS record does not contain an SNS message.");
 
@@ -31,7 +34,7 @@ public sealed class SnsNotificationContext : RecordContext
         SigningCertUrl = message.SigningCertUrl;
         UnsubscribeUrl = message.UnsubscribeUrl;
         MessageAttributes = message.MessageAttributes is null
-            ? new Dictionary<string, SNSEvent.MessageAttribute>()
+            ? EmptyMessageAttributes
             : new Dictionary<string, SNSEvent.MessageAttribute>(message.MessageAttributes);
     }
 
@@ -105,22 +108,7 @@ public sealed class SnsNotificationContext : RecordContext
         ArgumentNullException.ThrowIfNull(invocationContext);
         ArgumentNullException.ThrowIfNull(record);
 
-        var metadata = new FunctionContextMetadata(
-            invocationContext.AwsRequestId,
-            invocationContext.FunctionName,
-            invocationContext.FunctionVersion,
-            invocationContext.InvokedFunctionArn,
-            invocationContext.MemoryLimitInMB,
-            invocationContext.RemainingTime,
-            invocationContext.LogGroupName,
-            invocationContext.LogStreamName);
-
-        var properties = new Dictionary<string, object?>(invocationContext.Properties)
-        {
-            [SnsNotificationContextExtensions.SnsRecordPropertyName] = record
-        };
-
-        return new SnsNotificationContext(metadata, properties, record);
+        return new SnsNotificationContext(invocationContext, record);
     }
 }
 

--- a/tests/Tests.Lambda.Template/FunctionContextTests.cs
+++ b/tests/Tests.Lambda.Template/FunctionContextTests.cs
@@ -211,6 +211,7 @@ public class FunctionContextTests
                 firstPropertyName,
                 firstPropertyValue,
                 secondPropertyName,
-                secondPropertyValue) { }
+                secondPropertyValue)
+        { }
     }
 }

--- a/tests/Tests.Lambda.Template/FunctionContextTests.cs
+++ b/tests/Tests.Lambda.Template/FunctionContextTests.cs
@@ -109,6 +109,62 @@ public class FunctionContextTests
         });
     }
 
+    [Test]
+    public void Derived_context_two_property_overlay_exposes_both_properties_without_nesting()
+    {
+        var lambdaContext = TestLambdaContexts.Create();
+        var metadata = FunctionContextFactory.CreateMetadata(lambdaContext);
+        var properties = FunctionContextFactory.CreateProperties(lambdaContext);
+        properties["Source"] = "S3";
+
+        var source = new SpecializedRecordContext(metadata, properties);
+        var context = new TwoPropertyOverlaidRecordContext(
+            source,
+            "Request",
+            "request",
+            "Task",
+            "task");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Properties.Count, Is.EqualTo(source.Properties.Count + 2));
+            Assert.That(context.Properties["Request"], Is.EqualTo("request"));
+            Assert.That(context.Properties["Task"], Is.EqualTo("task"));
+            Assert.That(context.Properties["Source"], Is.EqualTo("S3"));
+            Assert.That(context.Properties.Keys.Count(key => key == "Request"), Is.EqualTo(1));
+            Assert.That(context.Properties.Keys.Count(key => key == "Task"), Is.EqualTo(1));
+            Assert.That(context.GetLambdaContext(), Is.SameAs(lambdaContext));
+        });
+    }
+
+    [Test]
+    public void Derived_context_two_property_overlay_handles_source_and_overlay_key_collisions()
+    {
+        var lambdaContext = TestLambdaContexts.Create();
+        var metadata = FunctionContextFactory.CreateMetadata(lambdaContext);
+        var properties = FunctionContextFactory.CreateProperties(lambdaContext);
+        properties["Request"] = "old";
+        properties["Other"] = 42;
+
+        var source = new SpecializedRecordContext(metadata, properties);
+        var context = new TwoPropertyOverlaidRecordContext(
+            source,
+            "Request",
+            "first",
+            "Request",
+            "second");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Properties.Count, Is.EqualTo(source.Properties.Count));
+            Assert.That(context.Properties["Request"], Is.EqualTo("second"));
+            Assert.That(context.Properties.TryGetValue("Request", out var value), Is.True);
+            Assert.That(value, Is.EqualTo("second"));
+            Assert.That(context.Properties.Keys.Count(key => key == "Request"), Is.EqualTo(1));
+            Assert.That(context.Properties.Count(pair => pair.Key == "Request"), Is.EqualTo(1));
+        });
+    }
+
     private sealed class SpecializedEventContext : EventContext
     {
         public SpecializedEventContext(
@@ -140,5 +196,21 @@ public class FunctionContextTests
             string propertyName,
             object? propertyValue)
             : base(source, propertyName, propertyValue) { }
+    }
+
+    private sealed class TwoPropertyOverlaidRecordContext : RecordContext
+    {
+        public TwoPropertyOverlaidRecordContext(
+            RecordContext source,
+            string firstPropertyName,
+            object? firstPropertyValue,
+            string secondPropertyName,
+            object? secondPropertyValue)
+            : base(
+                source,
+                firstPropertyName,
+                firstPropertyValue,
+                secondPropertyName,
+                secondPropertyValue) { }
     }
 }


### PR DESCRIPTION
## What changed

- Generalized the immutable `FunctionContext`/`RecordContext` property overlay so a derived record context can add either one or two fixed properties without cloning the invocation property bag.
- Kept SQS on the existing one-property overlay fast path.
- Ported the same allocation-saving construction pattern to SNS, Kinesis Streams, DynamoDB Streams, and S3 event records.
- Updated S3 Batch to add its request and task properties through one two-property overlay object rather than nested overlays or dictionary copies.
- Reused shared read-only empty dictionaries for SNS message attributes and S3 Batch user arguments.
- Added tests for two-property overlays, including enumeration/count behavior and key collisions.

## Why

The SQS performance investigation showed that recreating `FunctionContextMetadata` and copying invocation property dictionaries per record was the dominant avoidable allocation source. PR #86 removed that cost for SQS and cut the V6 raw allocation premium over V5 from about 1.21 KB/record to about 478 B/record.

The same cloning pattern still existed in the other record-source contexts. This PR applies the proven design consistently while preserving source-specific immutable contexts, raw AWS record access, partial-batch semantics, and per-record DI scopes.

## Design

The overlay remains a single immutable dictionary wrapper. It stores one or two fixed overlay entries directly; S3 Batch does not construct nested overlays. For duplicate overlay keys, the second value wins while count and enumeration still expose the key exactly once.

## Validation

The existing SQS optimization remains intact. CI should validate all source-specific behavior and the new overlay tests. Performance measurements can be added separately for the newly optimized record sources if we extend the benchmark suite beyond SQS.