### PR TITLE
Avoid record execution async state machine on synchronous completion

### DIFF
--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -286,7 +286,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         }
     }
 
-    private async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
+    private static async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
         ValueTask<TRecordResult> pendingResult)
     {
         var result = await pendingResult.ConfigureAwait(false);

--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -286,11 +286,12 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         }
     }
 
-    private static async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
+    private async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
         ValueTask<TRecordResult> pendingResult)
     {
         var result = await pendingResult.ConfigureAwait(false);
-        return result ?? throw new InvalidOperationException("Record exception handler returned a null result.");
+        return result ?? throw new InvalidOperationException(
+            $"Record exception handler for {typeof(THandler).Name} returned a null result.");
     }
 
     /// <summary>

--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -210,7 +210,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         return results;
     }
 
-    private async ValueTask<TRecordResult> ExecuteRecordAsync(
+    private ValueTask<TRecordResult> ExecuteRecordAsync(
         IRecordProcessor<TRecord, TRecordResult, TContext> processor,
         TRecord record,
         TContext context,
@@ -218,7 +218,13 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
     {
         try
         {
-            return await processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+            var pendingResult = processor.ProcessAsync(record, context, cancellationToken);
+            if (pendingResult.IsCompletedSuccessfully)
+            {
+                return pendingResult;
+            }
+
+            return AwaitRecordAsync(pendingResult, record, context, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -226,15 +232,65 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         }
         catch (Exception exception)
         {
-            var result = await HandleRecordExceptionAsync(
+            return HandleRecordExceptionResultAsync(record, exception, context, cancellationToken);
+        }
+    }
+
+    private async ValueTask<TRecordResult> AwaitRecordAsync(
+        ValueTask<TRecordResult> pendingResult,
+        TRecord record,
+        TContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await pendingResult.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            return await HandleRecordExceptionResultAsync(
                 record,
                 exception,
                 context,
                 cancellationToken).ConfigureAwait(false);
-
-            return result ?? throw new InvalidOperationException(
-                $"Record exception handler for {typeof(THandler).Name} returned a null result.");
         }
+    }
+
+    private ValueTask<TRecordResult> HandleRecordExceptionResultAsync(
+        TRecord record,
+        Exception exception,
+        TContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var pendingResult = HandleRecordExceptionAsync(record, exception, context, cancellationToken);
+            if (pendingResult.IsCompletedSuccessfully)
+            {
+                var result = pendingResult.Result
+                    ?? throw new InvalidOperationException(
+                        $"Record exception handler for {typeof(THandler).Name} returned a null result.");
+
+                return ValueTask.FromResult(result);
+            }
+
+            return AwaitRecordExceptionResultAsync(pendingResult);
+        }
+        catch (Exception handlerException)
+        {
+            return ValueTask.FromException<TRecordResult>(handlerException);
+        }
+    }
+
+    private static async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
+        ValueTask<TRecordResult> pendingResult)
+    {
+        var result = await pendingResult.ConfigureAwait(false);
+        return result ?? throw new InvalidOperationException("Record exception handler returned a null result.");
     }
 
     /// <summary>


### PR DESCRIPTION
## What changed

- Refactored `RecordFunction.ExecuteRecordAsync` so the common synchronously completed `ValueTask` path no longer creates an async state machine.
- Moved the true suspension path into a dedicated async helper.
- Added a synchronous fast path for record-exception translation when the source-specific exception handler also completes synchronously.

## Why

The post-context-fix performance investigation showed that async state-machine allocations in the generic record pipeline are now among the dominant remaining V6 per-record costs. The record contracts already use `ValueTask`, so the next opportunity is to avoid paying for `async` wrappers when the underlying processor completes synchronously.

## Semantics preserved

- cancellation still bypasses source-specific record-failure translation
- thrown processor exceptions still flow through `HandleRecordExceptionAsync`
- genuinely asynchronous processors/handlers still use an awaited fallback
- partial-batch result semantics are unchanged
- per-record DI scope behavior is unchanged

## Scope

This is intentionally the first narrow experiment. It removes the `ExecuteRecordAsync` state machine on successful synchronous completion without yet changing `RecordProcessor.ProcessAsync`, whose scope ownership/disposal makes the equivalent optimization more delicate.

## Validation

CI will validate behavior and formatting. The existing decomposition and end-to-end benchmarks should be rerun against this branch to measure the isolated benefit before attempting the deeper `RecordProcessor` fast path.