### PR TITLE
Update Lambda SystemTextJson serializer to 3.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Amazon.Lambda.Logging.AspNetCore" Version="5.0.0" />
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.1.2" />
     <PackageVersion Include="Amazon.Lambda.S3Events" Version="4.0.0" />
-    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.1" />
     <PackageVersion Include="Amazon.Lambda.SNSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.Lambda.TestUtilities" Version="4.2.0" />


### PR DESCRIPTION
## Summary

- update `Amazon.Lambda.Serialization.SystemTextJson` from 2.4.5 to 3.0.1
- remove the temporary downgrade used to avoid the NativeAOT regression in 3.0.0

## Context

AWS fixed the regression reported in aws/aws-lambda-dotnet#2531 in 3.0.1. The fix restores the AOT-related properties that were unintentionally dropped when adding the .NET 10 target.

## Validation

CI should exercise the normal build/test flow. The NativeAOT publish validation is expected to confirm that 3.0.1 no longer produces the IL3050/IL3053 warnings seen with 3.0.0.