### PR TITLE
Revert synchronous record execution fast path

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,6 +59,14 @@ Publishable performance measurements that require stable absolute comparisons sh
 
 The benchmark-validation GitHub Actions workflow only restores and builds this solution. It verifies the pinned SDK before building. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
 
+## Interpreting synchronous handler benchmarks
+
+The current SQS benchmark handlers complete synchronously with `ValueTask.FromResult` so that framework overhead remains visible. That makes the benchmark useful for decomposing costs, but it does not mean synchronous completion is the expected production workload for record handlers.
+
+Record handlers commonly perform genuinely asynchronous I/O. Optimizations that only avoid async machinery when the entire record-processing path completes synchronously should therefore be treated as microbenchmark-specific unless they also improve representative asynchronous workloads or remove work that is paid regardless of handler completion mode.
+
+PR #89 experimented with a synchronous fast path around `RecordFunction.ExecuteRecordAsync`. It was reverted after the post-merge benchmark showed no meaningful end-to-end allocation improvement and because making the underlying `RecordProcessor` synchronous-aware would add control-flow complexity primarily for handlers that do not suspend. Future performance work should prioritize costs that remain relevant for asynchronous handlers, such as unavoidable per-record framework work, DI scope/resolution overhead, and source-specific allocations.
+
 ## Current coverage
 
 ### Request functions

--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -210,7 +210,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         return results;
     }
 
-    private ValueTask<TRecordResult> ExecuteRecordAsync(
+    private async ValueTask<TRecordResult> ExecuteRecordAsync(
         IRecordProcessor<TRecord, TRecordResult, TContext> processor,
         TRecord record,
         TContext context,
@@ -218,13 +218,7 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
     {
         try
         {
-            var pendingResult = processor.ProcessAsync(record, context, cancellationToken);
-            if (pendingResult.IsCompletedSuccessfully)
-            {
-                return pendingResult;
-            }
-
-            return AwaitRecordAsync(pendingResult, record, context, cancellationToken);
+            return await processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -232,66 +226,15 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
         }
         catch (Exception exception)
         {
-            return HandleRecordExceptionResultAsync(record, exception, context, cancellationToken);
-        }
-    }
-
-    private async ValueTask<TRecordResult> AwaitRecordAsync(
-        ValueTask<TRecordResult> pendingResult,
-        TRecord record,
-        TContext context,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await pendingResult.ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            return await HandleRecordExceptionResultAsync(
+            var result = await HandleRecordExceptionAsync(
                 record,
                 exception,
                 context,
                 cancellationToken).ConfigureAwait(false);
+
+            return result ?? throw new InvalidOperationException(
+                $"Record exception handler for {typeof(THandler).Name} returned a null result.");
         }
-    }
-
-    private ValueTask<TRecordResult> HandleRecordExceptionResultAsync(
-        TRecord record,
-        Exception exception,
-        TContext context,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var pendingResult = HandleRecordExceptionAsync(record, exception, context, cancellationToken);
-            if (pendingResult.IsCompletedSuccessfully)
-            {
-                var result = pendingResult.Result
-                    ?? throw new InvalidOperationException(
-                        $"Record exception handler for {typeof(THandler).Name} returned a null result.");
-
-                return ValueTask.FromResult(result);
-            }
-
-            return AwaitRecordExceptionResultAsync(pendingResult);
-        }
-        catch (Exception handlerException)
-        {
-            return ValueTask.FromException<TRecordResult>(handlerException);
-        }
-    }
-
-    private static async ValueTask<TRecordResult> AwaitRecordExceptionResultAsync(
-        ValueTask<TRecordResult> pendingResult)
-    {
-        var result = await pendingResult.ConfigureAwait(false);
-        return result ?? throw new InvalidOperationException(
-            $"Record exception handler for {typeof(THandler).Name} returned a null result.");
     }
 
     /// <summary>


### PR DESCRIPTION
## What changed

- Reverts the `RecordFunction.ExecuteRecordAsync` synchronous-completion fast path introduced by #89.
- Restores the simpler awaited control flow for record processing and exception translation.
- Documents how synchronous record-handler benchmarks should be interpreted and why sync-only async-machinery optimizations are not a current target.

## Why

The post-merge benchmark after #89 did not show a meaningful end-to-end allocation improvement. More importantly, record handlers commonly perform genuinely asynchronous I/O, so a fast path that only helps when the entire record-processing stack completes synchronously optimizes a narrow benchmark shape rather than the expected production workload.

Making `RecordProcessor.ProcessAsync` synchronous-aware as well would add substantially more control-flow complexity around scope lifetime, cancellation, telemetry, and exception handling primarily to benefit handlers that do not suspend.

The benchmark guidance now records the decision: synchronous no-op handlers remain useful for exposing framework overhead, but performance work should prioritize costs that are paid regardless of handler completion mode or that improve representative asynchronous workloads.

## Scope

This reverts only the #89 production-code change. Context allocation optimizations from #86/#88 and the serializer update from #90 remain untouched.