### PR TITLE
Add asynchronous SQS benchmark workloads

### DIFF
--- a/benchmarks/BenchmarkWorkloads/AsyncWorkload.cs
+++ b/benchmarks/BenchmarkWorkloads/AsyncWorkload.cs
@@ -1,0 +1,9 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace BenchmarkWorkloads;
+
+public static class AsyncWorkload
+{
+    public static YieldAwaitable Suspend() => Task.Yield();
+}

--- a/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
@@ -4,8 +4,6 @@ using System.Threading.Tasks;
 
 using BenchmarkDotNet.Attributes;
 
-using BenchmarkWorkloads;
-
 namespace Benchmarks;
 
 [MemoryDiagnoser]

--- a/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using BenchmarkDotNet.Attributes;
 
+using BenchmarkWorkloads;
+
 namespace Benchmarks;
 
 [MemoryDiagnoser]

--- a/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
@@ -1,0 +1,66 @@
+#nullable enable
+
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class AsyncSqsBenchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsTarget? _rawSdk;
+    private ISqsTarget? _v5Typed;
+    private ISqsTarget? _v6Raw;
+    private ISqsTarget? _v6Typed;
+
+    [Params(1, 10, 100)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.UppercaseAsyncSqsTarget");
+        _v5Typed = _v5Session.CreateTarget<ISqsTarget>("V5Target.UppercaseAsyncSqsTarget");
+        _v6Raw = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseAsyncRawSqsTarget");
+        _v6Typed = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseAsyncTypedSqsTarget");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5Typed = null;
+        _v6Raw = null;
+        _v6Typed = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdkAsync() => _rawSdk!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V5TypedAsync() => _v5Typed!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6RawAsync() => _v6Raw!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6TypedAsync() => _v6Typed!.InvokeAsync(BatchSize);
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,14 +59,6 @@ Publishable performance measurements that require stable absolute comparisons sh
 
 The benchmark-validation GitHub Actions workflow only restores and builds this solution. It verifies the pinned SDK before building. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
 
-## Interpreting synchronous handler benchmarks
-
-The current SQS benchmark handlers complete synchronously with `ValueTask.FromResult` so that framework overhead remains visible. That makes the benchmark useful for decomposing costs, but it does not mean synchronous completion is the expected production workload for record handlers.
-
-Record handlers commonly perform genuinely asynchronous I/O. Optimizations that only avoid async machinery when the entire record-processing path completes synchronously should therefore be treated as microbenchmark-specific unless they also improve representative asynchronous workloads or remove work that is paid regardless of handler completion mode.
-
-PR #89 experimented with a synchronous fast path around `RecordFunction.ExecuteRecordAsync`. It was reverted after the post-merge benchmark showed no meaningful end-to-end allocation improvement and because making the underlying `RecordProcessor` synchronous-aware would add control-flow complexity primarily for handlers that do not suspend. Future performance work should prioritize costs that remain relevant for asynchronous handlers, such as unavoidable per-record framework work, DI scope/resolution overhead, and source-specific allocations.
-
 ## Current coverage
 
 ### Request functions
@@ -81,7 +73,7 @@ The workload itself is shared so the comparison focuses on invocation-framework 
 
 ### SQS functions
 
-The SQS benchmark measures batches of 1, 10, and 100 records and compares:
+The synchronous SQS benchmark measures batches of 1, 10, and 100 records and compares:
 
 - a plain AWS Lambda SQS handler (`RawSdk`), used as the BenchmarkDotNet baseline;
 - the published v5 typed SQS function (`V5Typed`);
@@ -89,3 +81,13 @@ The SQS benchmark measures batches of 1, 10, and 100 records and compares:
 - the current v6 typed SQS function (`V6Typed`).
 
 Every target receives an equivalent pre-built SQS envelope. Envelope construction and target loading happen during benchmark setup so the measured operation focuses on dispatch, decoding, record handling, and response construction.
+
+The synchronous handlers return already-completed tasks/value tasks. That makes this suite useful as a framework-overhead floor, but it should not be treated as representative of the completion mode of most production record handlers.
+
+### Asynchronous SQS functions
+
+`AsyncSqsBenchmarks` repeats the same Raw SDK, v5, v6 raw, and v6 typed comparison while forcing one real asynchronous suspension per record using the shared `AsyncWorkload.Suspend()` helper.
+
+The helper returns the awaitable produced by `Task.Yield()` directly so the benchmark remains deterministic, local, and independent of network or service latency without adding an extra helper `Task` state machine. It models the control-flow and allocation effects of a handler that actually suspends; it does not attempt to model DynamoDB, S3, HTTP, or other I/O latency.
+
+The synchronous and asynchronous suites should be interpreted together. A change that improves only the already-completed path may be interesting as framework-floor data, but production optimization decisions should not be driven by synchronous-only wins without checking the genuinely asynchronous path as well.

--- a/benchmarks/RawSdkTarget/SqsTarget.cs
+++ b/benchmarks/RawSdkTarget/SqsTarget.cs
@@ -28,6 +28,22 @@ public sealed class UppercaseSqsTarget : ISqsTarget
     }
 }
 
+public sealed class UppercaseAsyncSqsTarget : ISqsTarget
+{
+    private readonly UppercaseAsyncSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
 public sealed class UppercaseSqsFunction
 {
     public Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
@@ -44,6 +60,27 @@ public sealed class UppercaseSqsFunction
         {
             BatchItemFailures = []
         });
+    }
+}
+
+public sealed class UppercaseAsyncSqsFunction
+{
+    public async Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            await AsyncWorkload.Suspend();
+
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+            _ = SqsWorkload.Execute(message);
+        }
+
+        return new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        };
     }
 }
 

--- a/benchmarks/V5Target/SqsTarget.cs
+++ b/benchmarks/V5Target/SqsTarget.cs
@@ -33,6 +33,22 @@ public sealed class UppercaseSqsTarget : ISqsTarget
     }
 }
 
+public sealed class UppercaseAsyncSqsTarget : ISqsTarget
+{
+    private readonly UppercaseAsyncSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return 0;
+    }
+}
+
 public sealed class UppercaseSqsFunction : EventFunction<SQSEvent>
 {
     protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
@@ -45,6 +61,21 @@ public sealed class UppercaseSqsHandler : IMessageHandler<SqsBenchmarkMessage>
     {
         _ = SqsWorkload.Execute(message!);
         return Task.CompletedTask;
+    }
+}
+
+public sealed class UppercaseAsyncSqsFunction : EventFunction<SQSEvent>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        services.UseQueueMessageHandler<SqsBenchmarkMessage, UppercaseAsyncSqsHandler>();
+}
+
+public sealed class UppercaseAsyncSqsHandler : IMessageHandler<SqsBenchmarkMessage>
+{
+    public async Task HandleAsync(SqsBenchmarkMessage? message, ILambdaContext context)
+    {
+        await AsyncWorkload.Suspend();
+        _ = SqsWorkload.Execute(message!);
     }
 }
 

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -126,6 +126,7 @@ public sealed class UppercaseAsyncRawSqsHandler : ISqsRecordHandler
         cancellationToken.ThrowIfCancellationRequested();
 
         await AsyncWorkload.Suspend();
+        cancellationToken.ThrowIfCancellationRequested();
 
         var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
         _ = SqsWorkload.Execute(message);
@@ -146,6 +147,7 @@ public sealed class UppercaseAsyncTypedSqsHandler : ISqsMessageHandler<SqsBenchm
         cancellationToken.ThrowIfCancellationRequested();
 
         await AsyncWorkload.Suspend();
+        cancellationToken.ThrowIfCancellationRequested();
         _ = SqsWorkload.Execute(message);
 
         return SqsRecordResult.Success;

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -47,6 +47,38 @@ public sealed class UppercaseTypedSqsTarget : ISqsTarget
     }
 }
 
+public sealed class UppercaseAsyncRawSqsTarget : ISqsTarget
+{
+    private readonly UppercaseAsyncRawSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class UppercaseAsyncTypedSqsTarget : ISqsTarget
+{
+    private readonly UppercaseAsyncTypedSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
 public sealed class UppercaseRawSqsFunction : SqsFunction<UppercaseRawSqsHandler>;
 
 public sealed class UppercaseRawSqsHandler : ISqsRecordHandler
@@ -79,6 +111,44 @@ public sealed class UppercaseTypedSqsHandler : ISqsMessageHandler<SqsBenchmarkMe
         _ = SqsWorkload.Execute(message);
 
         return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+public sealed class UppercaseAsyncRawSqsFunction : SqsFunction<UppercaseAsyncRawSqsHandler>;
+
+public sealed class UppercaseAsyncRawSqsHandler : ISqsRecordHandler
+{
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage record,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await AsyncWorkload.Suspend();
+
+        var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+        _ = SqsWorkload.Execute(message);
+
+        return SqsRecordResult.Success;
+    }
+}
+
+public sealed class UppercaseAsyncTypedSqsFunction : SqsFunction<SqsBenchmarkMessage, UppercaseAsyncTypedSqsHandler>;
+
+public sealed class UppercaseAsyncTypedSqsHandler : ISqsMessageHandler<SqsBenchmarkMessage>
+{
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        SqsBenchmarkMessage message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await AsyncWorkload.Suspend();
+        _ = SqsWorkload.Execute(message);
+
+        return SqsRecordResult.Success;
     }
 }
 


### PR DESCRIPTION
Closes #93.

## What changed

- Adds a shared deterministic async suspension workload based on `Task.Yield()`.
- Adds Raw SDK, V5, V6 raw, and V6 typed SQS targets whose handlers genuinely suspend once per record.
- Adds a separate `AsyncSqsBenchmarks` suite for batch sizes 1, 10, and 100, while preserving the existing synchronous SQS suite as the framework-overhead floor.
- Keeps the benchmark implementations structurally aligned so the comparison focuses on async control-flow and framework overhead rather than external I/O.
- Documents how to interpret synchronous versus genuinely asynchronous results.

## Why

The existing synchronous SQS benchmark uses already-completed tasks/value tasks. That is useful for exposing framework overhead, but it should not drive optimization decisions by itself. The new async suite exercises the same Raw SDK / V5 / V6 comparison when every record actually suspends, without introducing network, storage, or service latency.

## Scope

`Task.Yield()` is intentionally synthetic. It models the control-flow and allocation effects of real suspension; it does not attempt to model DynamoDB, S3, HTTP, or other I/O latency.

This PR adds measurement coverage only. It does not change production runtime behavior.

## Validation

The benchmark-validation workflow builds the benchmark solution with the pinned .NET SDK 10.0.400. Full timed execution remains available locally and through the benchmark snapshot workflow.