### PR TITLE
Add SQS failure-rate benchmarks

### DIFF
--- a/benchmarks/BenchmarkWorkloads/SqsFailureWorkload.cs
+++ b/benchmarks/BenchmarkWorkloads/SqsFailureWorkload.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+
+namespace BenchmarkWorkloads;
+
+public enum SqsFailureMode
+{
+    ReturnedResult,
+    Exception
+}
+
+public interface ISqsFailureTarget
+{
+    Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode);
+}
+
+public sealed class SqsFailureBenchmarkMessage
+{
+    public string Message { get; set; } = string.Empty;
+
+    public bool ShouldFail { get; set; }
+}
+
+public static class SqsFailureWorkload
+{
+    public const int BatchSize = 10;
+
+    public static string CreateBody(bool shouldFail) =>
+        shouldFail
+            ? "{\"Message\":\"lambda benchmark\",\"ShouldFail\":true}"
+            : "{\"Message\":\"lambda benchmark\",\"ShouldFail\":false}";
+
+    public static bool ShouldFail(int recordIndex, int failurePercent) =>
+        recordIndex < BatchSize * failurePercent / 100;
+
+    public static string Execute(SqsFailureBenchmarkMessage message) =>
+        message.Message.ToUpperInvariant();
+}

--- a/benchmarks/Benchmarks/SqsExceptionFailureBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsExceptionFailureBenchmarks.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class SqsExceptionFailureBenchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsFailureTarget? _rawSdk;
+    private ISqsFailureTarget? _v5;
+    private ISqsFailureTarget? _v6Raw;
+    private ISqsFailureTarget? _v6Typed;
+
+    [Params(0, 10, 50, 100)]
+    public int FailurePercent { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsFailureTarget>("RawSdkTarget.FailureSqsTarget");
+        _v5 = _v5Session.CreateTarget<ISqsFailureTarget>("V5Target.FailureSqsTarget");
+        _v6Raw = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureRawSqsTarget");
+        _v6Typed = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureTypedSqsTarget");
+
+        ValidateTarget(_rawSdk, "RawSdk");
+        ValidateTarget(_v5, "V5RequestResponse");
+        ValidateTarget(_v6Raw, "V6Raw");
+        ValidateTarget(_v6Typed, "V6Typed");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5 = null;
+        _v6Raw = null;
+        _v6Typed = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdkExceptionFailure() =>
+        _rawSdk!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
+
+    [Benchmark]
+    public Task<int> V5RequestResponseExceptionFailure() =>
+        _v5!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
+
+    [Benchmark]
+    public Task<int> V6RawExceptionFailure() =>
+        _v6Raw!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
+
+    [Benchmark]
+    public Task<int> V6TypedExceptionFailure() =>
+        _v6Typed!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
+
+    private void ValidateTarget(ISqsFailureTarget target, string targetName)
+    {
+        var actual = target.InvokeAsync(FailurePercent, SqsFailureMode.Exception).GetAwaiter().GetResult();
+        var expected = SqsFailureWorkload.BatchSize * FailurePercent / 100;
+
+        if (actual != expected)
+        {
+            throw new InvalidOperationException(
+                $"{targetName} returned {actual} failed records; expected {expected} for {FailurePercent}% failures.");
+        }
+    }
+}

--- a/benchmarks/Benchmarks/SqsReturnedFailureBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsReturnedFailureBenchmarks.cs
@@ -1,0 +1,88 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class SqsReturnedFailureBenchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsFailureTarget? _rawSdk;
+    private ISqsFailureTarget? _v5;
+    private ISqsFailureTarget? _v6Raw;
+    private ISqsFailureTarget? _v6Typed;
+
+    [Params(0, 10, 50, 100)]
+    public int FailurePercent { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsFailureTarget>("RawSdkTarget.FailureSqsTarget");
+        _v5 = _v5Session.CreateTarget<ISqsFailureTarget>("V5Target.FailureSqsTarget");
+        _v6Raw = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureRawSqsTarget");
+        _v6Typed = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureTypedSqsTarget");
+
+        ValidateTarget(_rawSdk, "RawSdk");
+        ValidateTarget(_v5, "V5RequestResponse");
+        ValidateTarget(_v6Raw, "V6Raw");
+        ValidateTarget(_v6Typed, "V6Typed");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5 = null;
+        _v6Raw = null;
+        _v6Typed = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdkReturnedFailure() =>
+        _rawSdk!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
+
+    [Benchmark]
+    public Task<int> V5RequestResponseReturnedFailure() =>
+        _v5!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
+
+    [Benchmark]
+    public Task<int> V6RawReturnedFailure() =>
+        _v6Raw!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
+
+    [Benchmark]
+    public Task<int> V6TypedReturnedFailure() =>
+        _v6Typed!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
+
+    private void ValidateTarget(ISqsFailureTarget target, string targetName)
+    {
+        var actual = target.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult).GetAwaiter().GetResult();
+        var expected = SqsFailureWorkload.BatchSize * FailurePercent / 100;
+
+        if (actual != expected)
+        {
+            throw new InvalidOperationException(
+                $"{targetName} returned {actual} failed records; expected {expected} for {FailurePercent}% failures.");
+        }
+    }
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -88,6 +88,20 @@ The synchronous handlers return already-completed tasks/value tasks. That makes 
 
 `AsyncSqsBenchmarks` repeats the same Raw SDK, v5, v6 raw, and v6 typed comparison while forcing one real asynchronous suspension per record using the shared `AsyncWorkload.Suspend()` helper.
 
-The helper returns the awaitable produced by `Task.Yield()` directly so the benchmark remains deterministic, local, and independent of network or service latency without adding an extra helper `Task` state machine. It models the control-flow and allocation effects of a handler that actually suspends; it does not attempt to model DynamoDB, S3, HTTP, or other I/O latency.
+The helper returns `Task.Yield()` directly so the benchmark remains deterministic, local, and independent of network or service latency without adding a separate helper task state machine. It models the control-flow and allocation effects of a handler that actually suspends; it does not attempt to model DynamoDB, S3, HTTP, or other I/O latency.
 
 The synchronous and asynchronous suites should be interpreted together. A change that improves only the already-completed path may be interesting as framework-floor data, but production optimization decisions should not be driven by synchronous-only wins without checking the genuinely asynchronous path as well.
+
+### SQS partial-batch failures
+
+The failure benchmarks use a fixed batch of 10 records and cover deterministic 0%, 10%, 50%, and 100% failure rates with no randomness during measurement. The smaller matrix keeps exception-heavy runs practical while still covering all-success, one-failure, mixed-failure, and all-failure behavior.
+
+`SqsReturnedFailureBenchmarks` measures ordinary partial-batch failure results: the handler completes normally and identifies records that should be returned in `BatchItemFailures`. `SqsExceptionFailureBenchmarks` measures the distinct exception path, where per-record processing throws and the implementation translates the exception into the same logical partial-batch response. Both suites validate the expected failed-record count during BenchmarkDotNet setup before measurements begin.
+
+The Raw SDK target contains the hand-written record loop and failure collection needed to implement those semantics directly. V5 is also included, but its published SQS module has no per-record partial-batch result contract. The V5 benchmark therefore uses `RequestResponseFunction<SQSEvent, SQSBatchResponse>` and implements JSON decoding, record iteration, per-record exception handling, and response construction in the consumer handler. This is intentionally the realistic V5 route to obtain the same AWS behavior rather than inventing a V6-style abstraction inside the old SQS module.
+
+V6 measures both raw and typed record handlers and uses its built-in record-result and exception-translation pipeline. The comparison therefore captures not only runtime cost but also where the partial-batch plumbing lives in each programming model.
+
+The V6 exception benchmark functions clear logging providers so repeated BenchmarkDotNet invocations do not flood stdout with one error message per failed record. Exception handling and translation still run through the normal framework path, but provider output cost is intentionally excluded from this suite.
+
+The failure matrix remains synchronously completed to isolate the incremental cost of partial-batch handling and exception translation. The separate asynchronous SQS suite covers genuine suspension without multiplying every failure percentage by another completion-mode dimension.

--- a/benchmarks/RawSdkTarget/SqsFailureTarget.cs
+++ b/benchmarks/RawSdkTarget/SqsFailureTarget.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+namespace RawSdkTarget;
+
+public sealed class FailureSqsTarget : ISqsFailureTarget
+{
+    private readonly ReturnedFailureSqsFunction _returnedFunction = new();
+    private readonly ExceptionFailureSqsFunction _exceptionFunction = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsFailureEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode)
+    {
+        var response = mode switch
+        {
+            SqsFailureMode.ReturnedResult => await _returnedFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            SqsFailureMode.Exception => await _exceptionFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class ReturnedFailureSqsFunction
+{
+    public Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+                ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+            _ = SqsFailureWorkload.Execute(message);
+
+            if (message.ShouldFail)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure
+                {
+                    ItemIdentifier = record.MessageId
+                });
+            }
+        }
+
+        return Task.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = failures
+        });
+    }
+}
+
+public sealed class ExceptionFailureSqsFunction
+{
+    public Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            try
+            {
+                var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+                    ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+                _ = SqsFailureWorkload.Execute(message);
+
+                if (message.ShouldFail)
+                {
+                    throw new InvalidOperationException("benchmark failure");
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure
+                {
+                    ItemIdentifier = record.MessageId
+                });
+            }
+        }
+
+        return Task.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = failures
+        });
+    }
+}
+
+internal static class SqsFailureEnvelopeFactory
+{
+    private static readonly int[] FailurePercentages = [0, 10, 50, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        FailurePercentages.ToDictionary(failurePercent => failurePercent, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int failurePercent) =>
+        new()
+        {
+            Records = Enumerable.Range(0, SqsFailureWorkload.BatchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsFailureWorkload.CreateBody(SqsFailureWorkload.ShouldFail(index, failurePercent))
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V5Target/SqsFailureTarget.cs
+++ b/benchmarks/V5Target/SqsFailureTarget.cs
@@ -1,0 +1,128 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace V5Target;
+
+public sealed class FailureSqsTarget : ISqsFailureTarget
+{
+    private readonly ReturnedFailureSqsFunction _returnedFunction = new();
+    private readonly ExceptionFailureSqsFunction _exceptionFunction = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = FailureSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode)
+    {
+        var response = mode switch
+        {
+            SqsFailureMode.ReturnedResult => await _returnedFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            SqsFailureMode.Exception => await _exceptionFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class ReturnedFailureSqsFunction : RequestResponseFunction<SQSEvent, SQSBatchResponse>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        RegisterHandler<ReturnedFailureSqsHandler>(services);
+}
+
+public sealed class ReturnedFailureSqsHandler : IRequestResponseHandler<SQSEvent, SQSBatchResponse>
+{
+    public Task<SQSBatchResponse> HandleAsync(SQSEvent? input, ILambdaContext context)
+    {
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input?.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)!;
+            _ = SqsFailureWorkload.Execute(message);
+
+            if (message.ShouldFail)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure { ItemIdentifier = record.MessageId });
+            }
+        }
+
+        return Task.FromResult(new SQSBatchResponse { BatchItemFailures = failures });
+    }
+}
+
+public sealed class ExceptionFailureSqsFunction : RequestResponseFunction<SQSEvent, SQSBatchResponse>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        RegisterHandler<ExceptionFailureSqsHandler>(services);
+}
+
+public sealed class ExceptionFailureSqsHandler : IRequestResponseHandler<SQSEvent, SQSBatchResponse>
+{
+    public Task<SQSBatchResponse> HandleAsync(SQSEvent? input, ILambdaContext context)
+    {
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input?.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            try
+            {
+                ProcessRecord(record);
+            }
+            catch (InvalidOperationException)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure { ItemIdentifier = record.MessageId });
+            }
+        }
+
+        return Task.FromResult(new SQSBatchResponse { BatchItemFailures = failures });
+    }
+
+    private static void ProcessRecord(SQSEvent.SQSMessage record)
+    {
+        var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)!;
+        _ = SqsFailureWorkload.Execute(message);
+
+        if (message.ShouldFail)
+        {
+            throw new InvalidOperationException("Synthetic benchmark failure.");
+        }
+    }
+}
+
+internal static class FailureSqsEnvelopeFactory
+{
+    private static readonly int[] FailurePercentages = [0, 10, 50, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        FailurePercentages.ToDictionary(failurePercent => failurePercent, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int failurePercent) =>
+        new()
+        {
+            Records = Enumerable.Range(0, SqsFailureWorkload.BatchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsFailureWorkload.CreateBody(SqsFailureWorkload.ShouldFail(index, failurePercent))
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V6Target/SqsFailureTarget.cs
+++ b/benchmarks/V6Target/SqsFailureTarget.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Logging;
+
+namespace V6Target;
+
+public sealed class FailureRawSqsTarget : ISqsFailureTarget
+{
+    private readonly ReturnedFailureRawSqsFunction _returnedFunction = new();
+    private readonly ExceptionFailureRawSqsFunction _exceptionFunction = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsFailureEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode)
+    {
+        var response = mode switch
+        {
+            SqsFailureMode.ReturnedResult => await _returnedFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            SqsFailureMode.Exception => await _exceptionFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class FailureTypedSqsTarget : ISqsFailureTarget
+{
+    private readonly ReturnedFailureTypedSqsFunction _returnedFunction = new();
+    private readonly ExceptionFailureTypedSqsFunction _exceptionFunction = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsFailureEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode)
+    {
+        var response = mode switch
+        {
+            SqsFailureMode.ReturnedResult => await _returnedFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            SqsFailureMode.Exception => await _exceptionFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class ReturnedFailureRawSqsFunction : SqsFunction<ReturnedFailureRawSqsHandler>;
+
+public sealed class ReturnedFailureRawSqsHandler : ISqsRecordHandler
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage record,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+            ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+        _ = SqsFailureWorkload.Execute(message);
+
+        return ValueTask.FromResult(
+            message.ShouldFail
+                ? SqsRecordResult.Failed("benchmark failure")
+                : SqsRecordResult.Success);
+    }
+}
+
+public sealed class ExceptionFailureRawSqsFunction : SqsFunction<ExceptionFailureRawSqsHandler>
+{
+    protected override void ConfigureLogging(ILoggingBuilder logging) =>
+        logging.ClearProviders();
+}
+
+public sealed class ExceptionFailureRawSqsHandler : ISqsRecordHandler
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage record,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+            ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+        _ = SqsFailureWorkload.Execute(message);
+
+        if (message.ShouldFail)
+        {
+            throw new InvalidOperationException("benchmark failure");
+        }
+
+        return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+public sealed class ReturnedFailureTypedSqsFunction : SqsFunction<SqsFailureBenchmarkMessage, ReturnedFailureTypedSqsHandler>;
+
+public sealed class ReturnedFailureTypedSqsHandler : ISqsMessageHandler<SqsFailureBenchmarkMessage>
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SqsFailureBenchmarkMessage message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _ = SqsFailureWorkload.Execute(message);
+
+        return ValueTask.FromResult(
+            message.ShouldFail
+                ? SqsRecordResult.Failed("benchmark failure")
+                : SqsRecordResult.Success);
+    }
+}
+
+public sealed class ExceptionFailureTypedSqsFunction : SqsFunction<SqsFailureBenchmarkMessage, ExceptionFailureTypedSqsHandler>
+{
+    protected override void ConfigureLogging(ILoggingBuilder logging) =>
+        logging.ClearProviders();
+}
+
+public sealed class ExceptionFailureTypedSqsHandler : ISqsMessageHandler<SqsFailureBenchmarkMessage>
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SqsFailureBenchmarkMessage message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _ = SqsFailureWorkload.Execute(message);
+
+        if (message.ShouldFail)
+        {
+            throw new InvalidOperationException("benchmark failure");
+        }
+
+        return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+internal static class SqsFailureEnvelopeFactory
+{
+    private static readonly int[] FailurePercentages = [0, 10, 50, 100];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        FailurePercentages.ToDictionary(failurePercent => failurePercent, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int failurePercent) =>
+        new()
+        {
+            Records = Enumerable.Range(0, SqsFailureWorkload.BatchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = SqsFailureWorkload.CreateBody(SqsFailureWorkload.ShouldFail(index, failurePercent))
+                })
+                .ToList()
+        };
+}


### PR DESCRIPTION
Closes #94.

## What changed

- Adds deterministic SQS partial-batch failure benchmarks using a fixed batch of 10 records.
- Covers 0%, 10%, 50%, and 100% failure rates with no randomness during measurement.
- Adds separate suites for returned failures and per-record exceptions translated into partial-batch failures.
- Compares Raw SDK, a realistic V5 request/response implementation, and V6 raw and typed record handlers.
- Validates the expected failed-record count for every target during BenchmarkDotNet setup.
- Clears logging providers only on the V6 exception benchmark functions so repeated benchmark invocations do not flood stdout; exception handling and framework translation still execute normally.

## Why

The all-success SQS benchmarks expose framework overhead but do not exercise partial-batch response construction, continued processing after failures, or V6 exception-to-record-result translation. These suites measure the incremental cost of those behaviors.

The V5 comparison is intentionally realistic rather than symmetrical. Its published SQS module has no per-record partial-batch result contract, so the benchmark uses `RequestResponseFunction<SQSEvent, SQSBatchResponse>` and leaves JSON decoding, record iteration, failure collection, per-record try/catch, and response construction in consumer code.

## Scope

The matrix remains synchronously completed so it isolates failure handling. A batch of 10 keeps exception-heavy runs practical while still covering all-success, one-failure, mixed-failure, and all-failure cases. Genuine suspension is covered separately by PR #96.

Provider output cost is intentionally excluded from the V6 exception benchmark; the measured path still includes exception creation, catch/translation, record result handling, and response construction.

## Dependency

Stacked on PR #96. Merge #96 first, then retarget this PR to `master`.