### PR TITLE
Add nested SQS to SNS to S3 benchmark

### DIFF
--- a/benchmarks/BenchmarkWorkloads/NestedSqsSnsS3Workload.cs
+++ b/benchmarks/BenchmarkWorkloads/NestedSqsSnsS3Workload.cs
@@ -1,0 +1,14 @@
+namespace BenchmarkWorkloads;
+
+public static class NestedSqsSnsS3Workload
+{
+    public const string BucketName = "benchmark-bucket";
+    public const string ObjectKey = "benchmark-key.txt";
+
+    public const string S3EventJson = "{\"Records\":[{\"eventVersion\":\"2.1\",\"eventSource\":\"aws:s3\",\"awsRegion\":\"eu-north-1\",\"eventTime\":\"2026-08-18T00:00:00.000Z\",\"eventName\":\"ObjectCreated:Put\",\"userIdentity\":{\"principalId\":\"benchmark\"},\"requestParameters\":{\"sourceIPAddress\":\"127.0.0.1\"},\"responseElements\":{\"x-amz-request-id\":\"benchmark\",\"x-amz-id-2\":\"benchmark\"},\"s3\":{\"s3SchemaVersion\":\"1.0\",\"configurationId\":\"benchmark\",\"bucket\":{\"name\":\"benchmark-bucket\",\"ownerIdentity\":{\"principalId\":\"benchmark\"},\"arn\":\"arn:aws:s3:::benchmark-bucket\"},\"object\":{\"key\":\"benchmark-key.txt\",\"size\":1,\"eTag\":\"benchmark\",\"sequencer\":\"1\"}}}]}";
+
+    public const string SnsEnvelopeJson = "{\"Message\":\"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"eu-north-1\\\",\\\"eventTime\\\":\\\"2026-08-18T00:00:00.000Z\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"benchmark\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"127.0.0.1\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"benchmark\\\",\\\"x-amz-id-2\\\":\\\"benchmark\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"benchmark\\\",\\\"bucket\\\":{\\\"name\\\":\\\"benchmark-bucket\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"benchmark\\\"},\\\"arn\\\":\\\"arn:aws:s3:::benchmark-bucket\\\"},\\\"object\\\":{\\\"key\\\":\\\"benchmark-key.txt\\\",\\\"size\\\":1,\\\"eTag\\\":\\\"benchmark\\\",\\\"sequencer\\\":\\\"1\\\"}}}]}\"}";
+
+    public static string Execute(string bucketName, string objectKey) =>
+        $"{bucketName}/{objectKey}".ToUpperInvariant();
+}

--- a/benchmarks/Benchmarks/NestedAsyncSqsSnsS3Benchmarks.cs
+++ b/benchmarks/Benchmarks/NestedAsyncSqsSnsS3Benchmarks.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class NestedAsyncSqsSnsS3Benchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsTarget? _rawSdk;
+    private ISqsTarget? _v5;
+    private ISqsTarget? _v6;
+
+    [Params(1, 10)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.NestedAsyncSqsSnsS3Target");
+        _v5 = _v5Session.CreateTarget<ISqsTarget>("V5Target.NestedAsyncSqsSnsS3Target");
+        _v6 = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedAsyncSqsSnsS3Target");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5 = null;
+        _v6 = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdkAsync() => _rawSdk!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V5Async() => _v5!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6Async() => _v6!.InvokeAsync(BatchSize);
+}

--- a/benchmarks/Benchmarks/NestedSqsSnsS3Benchmarks.cs
+++ b/benchmarks/Benchmarks/NestedSqsSnsS3Benchmarks.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using BenchmarkWorkloads;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+public class NestedSqsSnsS3Benchmarks
+{
+    private TargetSession? _rawSdkSession;
+    private TargetSession? _v5Session;
+    private TargetSession? _v6Session;
+    private ISqsTarget? _rawSdk;
+    private ISqsTarget? _v5;
+    private ISqsTarget? _v6;
+
+    [Params(1, 10)]
+    public int BatchSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rawSdkSession = TargetSession.Create("RawSdkTargetAssemblyPath");
+        _v5Session = TargetSession.Create("V5TargetAssemblyPath");
+        _v6Session = TargetSession.Create("V6TargetAssemblyPath");
+
+        _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.NestedSqsSnsS3Target");
+        _v5 = _v5Session.CreateTarget<ISqsTarget>("V5Target.NestedSqsSnsS3Target");
+        _v6 = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedSqsSnsS3Target");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _rawSdk = null;
+        _v5 = null;
+        _v6 = null;
+
+        _rawSdkSession?.Dispose();
+        _v5Session?.Dispose();
+        _v6Session?.Dispose();
+
+        _rawSdkSession = null;
+        _v5Session = null;
+        _v6Session = null;
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<int> RawSdk() => _rawSdk!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V5() => _v5!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6() => _v6!.InvokeAsync(BatchSize);
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -105,3 +105,21 @@ V6 measures both raw and typed record handlers and uses its built-in record-resu
 The V6 exception benchmark functions clear logging providers so repeated BenchmarkDotNet invocations do not flood stdout with one error message per failed record. Exception handling and translation still run through the normal framework path, but provider output cost is intentionally excluded from this suite.
 
 The failure matrix remains synchronously completed to isolate the incremental cost of partial-batch handling and exception translation. The separate asynchronous SQS suite covers genuine suspension without multiplying every failure percentage by another completion-mode dimension.
+
+### Nested SQS to SNS to S3
+
+The nested-envelope benchmarks model an SQS batch where every message contains an SNS-style envelope whose `Message` contains one S3 event. Each S3 event contains one S3 object-created record.
+
+The suites use batches of 1 and 10 SQS messages and compare:
+
+- a Raw SDK implementation that owns SQS iteration, SNS-envelope decoding, S3-event decoding, and S3-record iteration directly;
+- a V5 implementation that uses the V5 typed SQS message handler for the outer SNS envelope, while application code still owns S3-event decoding and S3-record iteration;
+- a V6 implementation that follows the recommended nested flow: typed SQS handling for the SNS envelope, an S3 decoder, and the reusable S3 record processor/handler pipeline.
+
+The Raw SDK and V5 implementations use case-insensitive `System.Text.Json` options when manually decoding the canonical AWS S3 event JSON, matching the lowercase AWS property names without changing the shared fixture.
+
+`NestedSqsSnsS3Benchmarks` uses a synchronously completed S3 leaf handler. `NestedAsyncSqsSnsS3Benchmarks` uses the same deterministic `Task.Yield()` suspension at the S3 leaf so the nested pipeline is also measured when application work genuinely suspends.
+
+The V6 leaf handler also reads the originating raw SQS message from the propagated S3 record context. This exercises one of the context-propagation capabilities provided by the V6 record model rather than treating the extra pipeline solely as dispatch overhead.
+
+The runtime numbers should be read together with the structural difference between implementations. Raw SDK owns all envelope plumbing. V5 removes the outer SQS decoding but still leaves nested S3 parsing/iteration in application code. V6 supplies the source-specific S3 decoder/processor and context propagation, at the cost of the additional framework machinery those capabilities require.

--- a/benchmarks/RawSdkTarget/NestedSqsSnsS3Target.cs
+++ b/benchmarks/RawSdkTarget/NestedSqsSnsS3Target.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+namespace RawSdkTarget;
+
+public sealed class NestedSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedAsyncSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedSqsSnsS3Function
+{
+    public Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var sqsRecord in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            var snsEnvelope = JsonSerializer.Deserialize<NestedSnsEnvelope>(sqsRecord.Body, NestedJson.Options)
+                ?? throw new JsonException("The benchmark SNS envelope could not be deserialized.");
+            var s3Event = JsonSerializer.Deserialize<S3Event>(snsEnvelope.Message, NestedJson.Options)
+                ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit raw S3 record loop so the benchmark does not add LINQ allocations.
+            foreach (var s3Record in s3Event.Records ?? [])
+            {
+                _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+            }
+#pragma warning restore S3267
+        }
+
+        return Task.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        });
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Function
+{
+    public async Task<SQSBatchResponse> FunctionHandlerAsync(SQSEvent input, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        foreach (var sqsRecord in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            var snsEnvelope = JsonSerializer.Deserialize<NestedSnsEnvelope>(sqsRecord.Body, NestedJson.Options)
+                ?? throw new JsonException("The benchmark SNS envelope could not be deserialized.");
+            var s3Event = JsonSerializer.Deserialize<S3Event>(snsEnvelope.Message, NestedJson.Options)
+                ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit async raw S3 record loop so the benchmark does not add LINQ allocations.
+            foreach (var s3Record in s3Event.Records ?? [])
+            {
+                await AsyncWorkload.Suspend();
+                _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+            }
+#pragma warning restore S3267
+        }
+
+        return new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        };
+    }
+}
+
+public sealed class NestedSnsEnvelope
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+internal static class NestedJson
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}
+
+internal static class NestedSqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = NestedSqsSnsS3Workload.SnsEnvelopeJson
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/RawSdkTarget/RawSdkTarget.csproj
+++ b/benchmarks/RawSdkTarget/RawSdkTarget.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.S3Events" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" />
   </ItemGroup>

--- a/benchmarks/V5Target/NestedSqsSnsS3Target.cs
+++ b/benchmarks/V5Target/NestedSqsSnsS3Target.cs
@@ -1,0 +1,136 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace V5Target;
+
+public sealed class NestedSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return 0;
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedAsyncSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return 0;
+    }
+}
+
+public sealed class NestedSqsSnsS3Function : EventFunction<SQSEvent>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        services.UseQueueMessageHandler<NestedSnsEnvelope, NestedSqsSnsS3Handler>();
+}
+
+public sealed class NestedSqsSnsS3Handler : IMessageHandler<NestedSnsEnvelope>
+{
+    public Task HandleAsync(NestedSnsEnvelope? message, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var s3Event = JsonSerializer.Deserialize<S3Event>(message.Message, NestedJson.Options)
+            ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit V5 S3 record loop so the benchmark measures consumer-owned iteration without LINQ allocations.
+        foreach (var s3Record in s3Event.Records ?? [])
+        {
+            _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+        }
+#pragma warning restore S3267
+
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Function : EventFunction<SQSEvent>
+{
+    protected override void ConfigureServices(IServiceCollection services, IExecutionEnvironment executionEnvironment) =>
+        services.UseQueueMessageHandler<NestedSnsEnvelope, NestedAsyncSqsSnsS3Handler>();
+}
+
+public sealed class NestedAsyncSqsSnsS3Handler : IMessageHandler<NestedSnsEnvelope>
+{
+    public async Task HandleAsync(NestedSnsEnvelope? message, ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var s3Event = JsonSerializer.Deserialize<S3Event>(message.Message, NestedJson.Options)
+            ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit async V5 S3 record loop so the benchmark does not add LINQ allocations.
+        foreach (var s3Record in s3Event.Records ?? [])
+        {
+            await AsyncWorkload.Suspend();
+            _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+        }
+#pragma warning restore S3267
+    }
+}
+
+public sealed class NestedSnsEnvelope
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+internal static class NestedJson
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+}
+
+internal static class NestedSqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = NestedSqsSnsS3Workload.SnsEnvelopeJson
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V5Target/V5Target.csproj
+++ b/benchmarks/V5Target/V5Target.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.S3Events" Version="3.0.1" />
     <PackageReference Include="Amazon.Lambda.TestUtilities" Version="2.0.0" />
     <PackageReference Include="Kralizek.Lambda.Template" Version="5.0.0" />
     <PackageReference Include="Kralizek.Lambda.Template.Sqs" Version="5.0.0" />

--- a/benchmarks/V6Target/NestedSqsSnsS3Target.cs
+++ b/benchmarks/V6Target/NestedSqsSnsS3Target.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.S3Events;
+using Amazon.Lambda.SQSEvents;
+using Amazon.Lambda.TestUtilities;
+
+using BenchmarkWorkloads;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace V6Target;
+
+public sealed class NestedSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedAsyncSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedSqsSnsS3Function : SqsFunction<NestedSnsEnvelope, NestedSqsSnsS3Handler>
+{
+    protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddS3ObjectEventProcessing<NestedS3ObjectEventHandler>();
+        services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
+    }
+}
+
+public sealed class NestedAsyncSqsSnsS3Function : SqsFunction<NestedSnsEnvelope, NestedSqsSnsS3Handler>
+{
+    protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddS3ObjectEventProcessing<NestedAsyncS3ObjectEventHandler>();
+        services.TryAddSingleton<IStringPayloadDecoder<S3Event>, JsonStringPayloadDecoder<S3Event>>();
+    }
+}
+
+public sealed class NestedSnsEnvelope
+{
+    public string Message { get; set; } = string.Empty;
+}
+
+public sealed class NestedSqsSnsS3Handler : ISqsMessageHandler<NestedSnsEnvelope>
+{
+    private readonly IStringPayloadDecoder<S3Event> _s3Decoder;
+    private readonly IRecordProcessor<
+        S3Event.S3EventNotificationRecord,
+        S3RecordResult,
+        RecordContext> _s3Processor;
+
+    public NestedSqsSnsS3Handler(
+        IStringPayloadDecoder<S3Event> s3Decoder,
+        IRecordProcessor<S3Event.S3EventNotificationRecord, S3RecordResult, RecordContext> s3Processor)
+    {
+        _s3Decoder = s3Decoder;
+        _s3Processor = s3Processor;
+    }
+
+    public async ValueTask<SqsRecordResult> HandleAsync(
+        NestedSnsEnvelope message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+    {
+        var s3Event = await _s3Decoder.DecodeAsync(message.Message, cancellationToken).ConfigureAwait(false);
+
+        foreach (var record in (IEnumerable<S3Event.S3EventNotificationRecord>?)s3Event.Records ?? Array.Empty<S3Event.S3EventNotificationRecord>())
+        {
+            await _s3Processor.ProcessAsync(record, context, cancellationToken).ConfigureAwait(false);
+        }
+
+        return SqsRecordResult.Success;
+    }
+}
+
+public sealed class NestedS3ObjectEventHandler : IS3ObjectEventHandler
+{
+    public ValueTask HandleAsync(
+        S3ObjectEvent item,
+        S3RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _ = context.GetSqsMessage();
+        _ = NestedSqsSnsS3Workload.Execute(item.Object.Bucket, item.Object.Key);
+        return ValueTask.CompletedTask;
+    }
+}
+
+public sealed class NestedAsyncS3ObjectEventHandler : IS3ObjectEventHandler
+{
+    public async ValueTask HandleAsync(
+        S3ObjectEvent item,
+        S3RecordContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        _ = context.GetSqsMessage();
+
+        await AsyncWorkload.Suspend();
+        _ = NestedSqsSnsS3Workload.Execute(item.Object.Bucket, item.Object.Key);
+    }
+}
+
+internal static class NestedSqsEnvelopeFactory
+{
+    private static readonly int[] BatchSizes = [1, 10];
+
+    public static IReadOnlyDictionary<int, SQSEvent> Create() =>
+        BatchSizes.ToDictionary(batchSize => batchSize, CreateEnvelope);
+
+    private static SQSEvent CreateEnvelope(int batchSize) =>
+        new()
+        {
+            Records = Enumerable.Range(0, batchSize)
+                .Select(index => new SQSEvent.SQSMessage
+                {
+                    MessageId = $"message-{index}",
+                    Body = NestedSqsSnsS3Workload.SnsEnvelopeJson
+                })
+                .ToList()
+        };
+}

--- a/benchmarks/V6Target/V6Target.csproj
+++ b/benchmarks/V6Target/V6Target.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BenchmarkWorkloads\BenchmarkWorkloads.csproj" />
     <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.S3\Kralizek.Lambda.Template.S3.csproj" />
     <ProjectReference Include="..\..\src\Kralizek.Lambda.Template.Sqs\Kralizek.Lambda.Template.Sqs.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #95.

## What changed

- Adds a deterministic nested `SQS -> SNS envelope -> S3 event -> S3 record` benchmark workload.
- Adds Raw SDK, V5, and V6 implementations for the same nested payload shape.
- Adds separate synchronous-leaf and genuinely asynchronous-leaf BenchmarkDotNet suites for batch sizes 1 and 10.
- Uses the recommended V6 composition: typed SQS envelope handling, S3 decoding, reusable S3 record processing, and source-context propagation.
- Exercises V6 origin propagation by reading the originating raw SQS message from the S3 record context.
- Keeps the shared fixture in canonical AWS JSON form; Raw SDK and V5 use case-insensitive `System.Text.Json` options for their consumer-owned S3 deserialization.

## Comparability

The Raw SDK target owns SQS iteration, SNS-envelope decoding, S3-event decoding, and S3-record iteration directly.

V5 uses its typed SQS message handler for the outer SNS envelope, while application code still owns S3-event decoding and S3-record iteration. The V5 target pins `Amazon.Lambda.S3Events` 3.0.1 because the isolated V5 benchmark remains on .NET 6.

V6 uses typed SQS handling for the SNS envelope and delegates S3 decoding/record processing to the source-specific framework pipeline. The S3 leaf also reads the originating SQS record from propagated context, so the benchmark measures that capability as part of the V6 programming model.

## Scope

Each SQS message contains one SNS-style envelope, each envelope contains one S3 event, and each S3 event contains one object-created record. The async suite suspends once at the S3 leaf using the same deterministic `Task.Yield()` workload introduced in PR #96.

The benchmark is intended to show both runtime cost and the structural difference in how much envelope plumbing each programming model leaves to consumer code.

## Dependency

Stacked on PR #97, which is stacked on PR #96. Merge in order #96 -> #97 -> this PR, then retarget each downstream PR to `master`.