### PR TITLE
Add benchmark execution profiles

### DIFF
--- a/.github/workflows/benchmark-validation.yml
+++ b/.github/workflows/benchmark-validation.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'benchmarks/**'
+      - '.github/workflows/benchmark-validation.yml'
+      - '.github/workflows/release-benchmarks.yml'
   workflow_dispatch:
 
 concurrency:
@@ -33,3 +35,10 @@ jobs:
       - name: Build benchmark solution
         working-directory: benchmarks
         run: dotnet build Benchmarks.slnx --configuration Release --no-incremental -warnaserror
+
+      - name: Validate benchmark profiles
+        working-directory: benchmarks
+        run: |
+          dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --profile full --list flat
+          dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --profile ci --list flat
+          dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --profile stress --list flat

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -47,6 +47,7 @@ jobs:
           --project Benchmarks/Benchmarks.csproj
           --configuration Release
           --
+          --profile ci
           --filter '*'
           --exporters json
           --artifacts "$RUNNER_TEMP/BenchmarkDotNet.Artifacts"
@@ -103,7 +104,7 @@ jobs:
           cd "$RUNNER_TEMP"
           zip -r benchmark-results.zip BenchmarkDotNet.Artifacts
 
-      - name: Attach snapshot to GitHub release when available
+      - name: Attach benchmark snapshot to GitHub release when available
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release-tag }}

--- a/benchmarks/Benchmarks/BenchmarkProfiles.cs
+++ b/benchmarks/Benchmarks/BenchmarkProfiles.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Running;
+
+namespace Benchmarks;
+
+internal enum BenchmarkProfile
+{
+    Full,
+    Ci,
+    Stress
+}
+
+internal static class BenchmarkProfiles
+{
+    public static BenchmarkProfile Parse(string value) =>
+        value.ToLowerInvariant() switch
+        {
+            "full" => BenchmarkProfile.Full,
+            "ci" => BenchmarkProfile.Ci,
+            "stress" => BenchmarkProfile.Stress,
+            _ => throw new ArgumentException($"Unknown benchmark profile '{value}'. Expected one of: full, ci, stress.")
+        };
+
+    public static IFilter CreateFilter(BenchmarkProfile profile) =>
+        new ProfileFilter(profile);
+
+    private sealed class ProfileFilter(BenchmarkProfile profile) : IFilter
+    {
+        private const string BatchSizeParameter = "BatchSize";
+        private const string FailurePercentParameter = "FailurePercent";
+
+        public bool Predicate(BenchmarkCase benchmarkCase)
+        {
+            if (profile == BenchmarkProfile.Full)
+            {
+                return true;
+            }
+
+            var benchmarkType = benchmarkCase.Descriptor.Type;
+
+            return profile switch
+            {
+                BenchmarkProfile.Ci => IsCiBenchmark(benchmarkType, benchmarkCase),
+                BenchmarkProfile.Stress => IsStressBenchmark(benchmarkType, benchmarkCase),
+                _ => false
+            };
+        }
+
+        private static bool IsCiBenchmark(Type benchmarkType, BenchmarkCase benchmarkCase) =>
+            benchmarkType == typeof(RequestBenchmarks) ||
+            benchmarkType == typeof(SqsBenchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 10) ||
+            benchmarkType == typeof(AsyncSqsBenchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 10) ||
+            benchmarkType == typeof(SqsReturnedFailureBenchmarks) && HasParameter(benchmarkCase, FailurePercentParameter, 10) ||
+            benchmarkType == typeof(SqsExceptionFailureBenchmarks) && HasParameter(benchmarkCase, FailurePercentParameter, 10) ||
+            benchmarkType == typeof(NestedSqsSnsS3Benchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 1) ||
+            benchmarkType == typeof(NestedAsyncSqsSnsS3Benchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 1);
+
+        private static bool IsStressBenchmark(Type benchmarkType, BenchmarkCase benchmarkCase) =>
+            benchmarkType == typeof(SqsBenchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 100) ||
+            benchmarkType == typeof(AsyncSqsBenchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 100) ||
+            benchmarkType == typeof(SqsReturnedFailureBenchmarks) && HasParameter(benchmarkCase, FailurePercentParameter, 50, 100) ||
+            benchmarkType == typeof(SqsExceptionFailureBenchmarks) && HasParameter(benchmarkCase, FailurePercentParameter, 50, 100) ||
+            benchmarkType == typeof(NestedSqsSnsS3Benchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 10) ||
+            benchmarkType == typeof(NestedAsyncSqsSnsS3Benchmarks) && HasParameter(benchmarkCase, BatchSizeParameter, 10);
+
+        private static bool HasParameter(BenchmarkCase benchmarkCase, string name, params int[] expectedValues)
+        {
+            var parameter = benchmarkCase.Parameters.Items.SingleOrDefault(item => item.Name == name);
+            return parameter?.Value is int value && expectedValues.Contains(value);
+        }
+    }
+}

--- a/benchmarks/Benchmarks/Program.cs
+++ b/benchmarks/Benchmarks/Program.cs
@@ -1,12 +1,65 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
-var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args).ToArray();
+using Benchmarks;
 
-return summaries.Length == 0 ||
+var (profile, benchmarkArgs) = ParseProfile(args);
+var isListCommand = benchmarkArgs.Any(argument =>
+    string.Equals(argument, "--list", StringComparison.OrdinalIgnoreCase) ||
+    argument.StartsWith("--list=", StringComparison.OrdinalIgnoreCase));
+
+var config = ManualConfig.Create(DefaultConfig.Instance)
+    .AddFilter(BenchmarkProfiles.CreateFilter(profile));
+
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly)
+    .Run(benchmarkArgs, config)
+    .ToArray();
+
+return (!isListCommand && summaries.Length == 0) ||
        summaries.Any(summary =>
            summary.ValidationErrors.Any(error => error.IsCritical) ||
            summary.Reports.Any(report => !report.Success))
     ? 1
     : 0;
+
+static (BenchmarkProfile Profile, string[] Args) ParseProfile(string[] args)
+{
+    var profile = BenchmarkProfile.Full;
+    var remainingArgs = new List<string>(args.Length);
+    var index = 0;
+
+    while (index < args.Length)
+    {
+        var argument = args[index];
+
+        if (argument.StartsWith("--profile=", StringComparison.OrdinalIgnoreCase))
+        {
+            profile = BenchmarkProfiles.Parse(argument["--profile=".Length..]);
+            index++;
+            continue;
+        }
+
+        if (string.Equals(argument, "--profile", StringComparison.OrdinalIgnoreCase))
+        {
+            index++;
+
+            if (index >= args.Length)
+            {
+                throw new ArgumentException("--profile requires a value: full, ci, or stress.");
+            }
+
+            profile = BenchmarkProfiles.Parse(args[index]);
+            index++;
+            continue;
+        }
+
+        remainingArgs.Add(argument);
+        index++;
+    }
+
+    return (profile, remainingArgs.ToArray());
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,7 +34,20 @@ Run all benchmarks:
 dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build
 ```
 
-Use BenchmarkDotNet filters when developing or investigating a specific benchmark suite:
+The benchmark host supports three execution profiles through `--profile`:
+
+- `full` is the default and runs the complete benchmark matrix. This is the normal choice for local and controlled-hardware measurements.
+- `ci` runs a small representative set intended for GitHub-hosted runners: request, synchronous SQS batch 10, asynchronous SQS batch 10, returned and exception failures at 10%, and synchronous/asynchronous nested SQS to SNS to S3 with batch 1.
+- `stress` runs the heavier scaling and edge cases: synchronous/asynchronous SQS batch 100, returned and exception failures at 50% and 100%, and synchronous/asynchronous nested SQS to SNS to S3 with batch 10.
+
+Examples:
+
+```bash
+dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --profile ci
+dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --profile stress
+```
+
+Profiles compose with normal BenchmarkDotNet command-line filters. Use BenchmarkDotNet filters when developing or investigating a specific benchmark suite:
 
 ```bash
 dotnet run --project Benchmarks/Benchmarks.csproj --configuration Release --no-build -- --filter "*RequestBenchmarks*"
@@ -45,9 +58,9 @@ All normal BenchmarkDotNet command-line options remain available. BenchmarkDotNe
 
 ## Release benchmark history
 
-`.github/workflows/release-benchmarks.yml` runs the BenchmarkDotNet host directly and requests its standard JSON exporter. The raw `BenchmarkDotNet.Artifacts` directory is retained as a GitHub Actions artifact for troubleshooting.
+`.github/workflows/release-benchmarks.yml` runs the `ci` benchmark profile and requests BenchmarkDotNet's standard JSON exporter. The raw `BenchmarkDotNet.Artifacts` directory is retained as a GitHub Actions artifact for troubleshooting.
 
-For real release runs, the workflow passes those JSON results to `martincostello/benchmarkdotnet-results-publisher`, which appends the summarized measurements to the repository's `gh-pages` branch. This gives the project a durable release-to-release history without maintaining a custom result schema, metadata manifest, directory convention, or release ZIP format.
+For real release runs, the workflow passes those JSON results to `martincostello/benchmarkdotnet-results-publisher`, which appends the summarized measurements to the repository's `benchmark-history` branch. This gives the project a durable release-to-release history without maintaining a custom result schema, metadata manifest, directory convention, or release ZIP format.
 
 Manual executions of the benchmark workflow still produce the raw Actions artifact but do not publish into the historical data set.
 
@@ -57,7 +70,7 @@ The published data is intended for relative trend analysis. GitHub-hosted runner
 
 Publishable performance measurements that require stable absolute comparisons should still be collected on controlled hardware. Keep the machine on external power where applicable and avoid material background workloads while collecting results.
 
-The benchmark-validation GitHub Actions workflow only restores and builds this solution. It verifies the pinned SDK before building. It proves that benchmark code remains valid when source or benchmark infrastructure changes; it does not produce performance results.
+The benchmark-validation GitHub Actions workflow verifies the pinned SDK, builds the benchmark solution, and exercises the `full`, `ci`, and `stress` profile selectors through BenchmarkDotNet list mode. It proves that benchmark code and profile selection remain valid without producing timed performance results.
 
 ## Current coverage
 


### PR DESCRIPTION
## What changed

- Adds benchmark execution profiles to the BenchmarkDotNet host via `--profile`.
- Keeps `full` as the default profile and preserves the complete benchmark matrix for local and controlled-hardware runs.
- Adds a `ci` profile with seven representative canary configurations for GitHub-hosted runners.
- Adds a `stress` profile for heavier scaling and edge-case configurations.
- Updates the benchmark snapshot workflow to run the `ci` profile instead of the full matrix.
- Extends benchmark validation so `full`, `ci`, and `stress` are exercised through BenchmarkDotNet list mode without running timed benchmarks.
- Keeps normal BenchmarkDotNet filters composable with profiles and treats list-only execution as a successful non-benchmark command.
- Updates benchmark documentation to describe the final profile behavior, profile validation, and the `benchmark-history` results branch.

## Profiles

- `full`: complete benchmark matrix; default when `--profile` is omitted.
- `ci`: request; sync/async SQS batch 10; returned/exception failures at 10%; sync/async nested SQS→SNS→S3 batch 1.
- `stress`: sync/async SQS batch 100; returned/exception failures at 50% and 100%; sync/async nested SQS→SNS→S3 batch 10.

## Why

GitHub-hosted runners are useful for relative trend canaries but are not controlled benchmark hardware. The profile split keeps the hosted history focused on representative execution paths while preserving the broader matrix for local investigation and controlled measurements.

The benchmark-validation workflow remains non-timed: it builds the benchmark solution and verifies that all three profile selectors can enumerate benchmark cases successfully.

## Dependency

Stacked on PR #98, which is stacked on #97 and #96. Merge in order #96 → #97 → #98 → this PR.