### PR TITLE
Add minimal Lambda hosting model

### DIFF
--- a/.github/template-smoke-tests.json
+++ b/.github/template-smoke-tests.json
@@ -11,6 +11,17 @@
       "mustNotMatch": ["OpenTelemetry"]
     },
     {
+      "name": "Event (Minimal)",
+      "shortName": "lambda-template-event",
+      "projectName": "SmokeEventMinimal",
+      "when": ["pr", "master", "release"],
+      "minimal": true,
+      "mustExist": ["Function.cs", "StringEventHandler.cs", "SmokeEventMinimal.csproj"],
+      "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
+      "mustMatch": ["MinimalEventFunction<string, StringEventHandler>", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"],
+      "mustNotMatch": ["LambdaTelemetry", "OpenTelemetry", "MeterProvider"]
+    },
+    {
       "name": "Event (OpenTelemetry)",
       "shortName": "lambda-template-event",
       "projectName": "SmokeEventOtel",
@@ -20,6 +31,18 @@
       "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
       "mustMatch": ["EventFunction<string, StringEventHandler>", "OpenTelemetry\\.Instrumentation\\.AWSLambda", "AWSLambdaWrapper\\.TraceAsync", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"],
       "mustNotMatch": []
+    },
+    {
+      "name": "Event (Minimal, OpenTelemetry)",
+      "shortName": "lambda-template-event",
+      "projectName": "SmokeEventMinimalOtel",
+      "when": ["pr", "master", "release"],
+      "minimal": true,
+      "otel": true,
+      "mustExist": ["Function.cs", "StringEventHandler.cs", "SmokeEventMinimalOtel.csproj"],
+      "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
+      "mustMatch": ["MinimalEventFunction<string, StringEventHandler>", "OpenTelemetry\\.Instrumentation\\.AWSLambda", "AWSLambdaWrapper\\.TraceAsync", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"],
+      "mustNotMatch": ["LambdaTelemetry", "MeterProvider", "AddMeter"]
     },
     {
       "name": "Request",
@@ -32,6 +55,17 @@
       "mustNotMatch": ["OpenTelemetry"]
     },
     {
+      "name": "Request (Minimal)",
+      "shortName": "lambda-template-request",
+      "projectName": "SmokeRequestMinimal",
+      "when": ["pr", "master", "release"],
+      "minimal": true,
+      "mustExist": ["Function.cs", "ToUpperStringRequestHandler.cs", "SmokeRequestMinimal.csproj"],
+      "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
+      "mustMatch": ["MinimalRequestFunction<string, string, ToUpperStringRequestHandler>", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"],
+      "mustNotMatch": ["LambdaTelemetry", "OpenTelemetry", "MeterProvider"]
+    },
+    {
       "name": "Request (OpenTelemetry)",
       "shortName": "lambda-template-request",
       "projectName": "SmokeRequestOtel",
@@ -41,6 +75,18 @@
       "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
       "mustMatch": ["RequestFunction<string, string, ToUpperStringRequestHandler>", "OpenTelemetry\\.Instrumentation\\.AWSLambda", "AWSLambdaWrapper\\.TraceAsync", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"],
       "mustNotMatch": []
+    },
+    {
+      "name": "Request (Minimal, Native AOT)",
+      "shortName": "lambda-template-request",
+      "projectName": "SmokeRequestMinimalAot",
+      "when": ["pr", "master", "release"],
+      "minimal": true,
+      "aot": true,
+      "mustExist": ["Function.cs", "Program.cs", "ToUpperStringRequestHandler.cs", "SmokeRequestMinimalAot.csproj"],
+      "mustNotExist": ["LambdaFunctionProject.csproj", ".template.config"],
+      "mustMatch": ["MinimalRequestFunction<string, string, ToUpperStringRequestHandler>", "LambdaBootstrapBuilder", "SourceGeneratorLambdaJsonSerializer", "<PublishAot>true</PublishAot>", "<OutputType>Exe</OutputType>", "\"function-handler\": \"SmokeRequestMinimalAot\""],
+      "mustNotMatch": ["LambdaTelemetry", "OpenTelemetry", "DefaultLambdaJsonSerializer", "::FunctionHandlerAsync"]
     },
     {
       "name": "EventBridge",

--- a/.github/template-smoke-tests.schema.json
+++ b/.github/template-smoke-tests.schema.json
@@ -68,6 +68,10 @@
           "type": "boolean",
           "default": false
         },
+        "minimal": {
+          "type": "boolean",
+          "default": false
+        },
         "version": {
           "type": "string",
           "enum": ["v1", "v2"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,7 @@ jobs:
           TEMPLATE_AOT: ${{ matrix.aot || false }}
           TEMPLATE_OTEL: ${{ matrix.otel || false }}
           TEMPLATE_RAW: ${{ matrix.raw || false }}
+          TEMPLATE_MINIMAL: ${{ matrix.minimal || false }}
           TEMPLATE_VERSION: ${{ matrix.version || '' }}
         shell: bash
         run: |
@@ -428,6 +429,9 @@ jobs:
           fi
           if [ "$TEMPLATE_RAW" = "true" ]; then
             args+=(--raw)
+          fi
+          if [ "$TEMPLATE_MINIMAL" = "true" ]; then
+            args+=(--minimal)
           fi
           if [ -n "$TEMPLATE_VERSION" ]; then
             args+=(--version "$TEMPLATE_VERSION")

--- a/AWSLambdaSharpTemplate.slnx
+++ b/AWSLambdaSharpTemplate.slnx
@@ -6,6 +6,8 @@
     <Project Path="samples/EventBridgeFunction/EventBridgeFunction.csproj" />
     <Project Path="samples/EventFunction/EventFunction.csproj" />
     <Project Path="samples/KinesisStreamFunction/KinesisStreamFunction.csproj" />
+    <Project Path="samples/MinimalEventFunction/MinimalEventFunction.csproj" />
+    <Project Path="samples/MinimalRequestFunction/MinimalRequestFunction.csproj" />
     <Project Path="samples/NativeAotSqsFunction/NativeAotSqsFunction.csproj" />
     <Project Path="samples/NativeAotSqsSnsS3Function/NativeAotSqsSnsS3Function.csproj" />
     <Project Path="samples/OpenTelemetryEventFunction/OpenTelemetryEventFunction.csproj" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Version 6 is a major redesign of the library and template set. It replaces the V
 
 - Added the lightweight `Kralizek.Lambda.Template.Abstractions` package containing handler contracts, function contexts, record-result abstractions, and payload decoder interfaces without dependencies on the Lambda runtime or Microsoft.Extensions infrastructure.
 - Added strongly typed `EventContext`, `RequestContext`, and `RecordContext` models, while retaining access to the original `ILambdaContext` through the runtime package when needed.
+- Added `MinimalEventFunction` and `MinimalRequestFunction` as lean alternative hosts for the existing v6 Event/Request handler contracts. Minimal hosting retains configuration, logging, function-local dependency injection, invocation scopes, v6 contexts, cancellation, and async scope disposal while omitting the full host's internal telemetry and richer processing path.
+- Added `--minimal` to the generic Request and Event templates, including Native AOT and OpenTelemetry composition. Minimal OpenTelemetry keeps the AWS Lambda invocation wrapper without subscribing to KLT's internal activity source or meter.
 - Added built-in plain-text and System.Text.Json string/binary payload decoders, including support for source-generated JSON metadata.
 - Added SQS support for both decoded messages and raw records, including bounded parallel variants and partial-batch failure responses.
 - Added SNS support for both decoded notifications and raw records, including bounded parallel variants and SNS whole-invocation failure semantics.
@@ -33,7 +35,7 @@ Version 6 is a major redesign of the library and template set. It replaces the V
 - Added S3 Batch Operations schema 2.0 support with typed task models and explicit success, temporary-failure, and permanent-failure results.
 - Added Kinesis Streams support for raw records and decoded binary payloads, stream-specific result types, and partial-batch failure responses.
 - Added source-specific samples and `dotnet new` templates for the supported integrations.
-- Added template smoke tests that install the packed template package, instantiate every template, restore its runtime dependencies from the locally packed packages, and build the generated project as an external consumer.
+- Added template smoke tests that install the packed template package, instantiate every template, restore its runtime dependencies from the locally packed packages, and build the generated project as an external consumer, including representative Minimal Request/Event, OpenTelemetry, and Native AOT cases.
 
 ### Changed
 

--- a/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/AsyncSqsBenchmarks.cs
@@ -16,6 +16,7 @@ public class AsyncSqsBenchmarks
     private TargetSession? _v6Session;
     private ISqsTarget? _rawSdk;
     private ISqsTarget? _v5Typed;
+    private ISqsTarget? _v6Minimal;
     private ISqsTarget? _v6Raw;
     private ISqsTarget? _v6Typed;
 
@@ -31,6 +32,7 @@ public class AsyncSqsBenchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.UppercaseAsyncSqsTarget");
         _v5Typed = _v5Session.CreateTarget<ISqsTarget>("V5Target.UppercaseAsyncSqsTarget");
+        _v6Minimal = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseAsyncMinimalSqsTarget");
         _v6Raw = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseAsyncRawSqsTarget");
         _v6Typed = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseAsyncTypedSqsTarget");
     }
@@ -40,6 +42,7 @@ public class AsyncSqsBenchmarks
     {
         _rawSdk = null;
         _v5Typed = null;
+        _v6Minimal = null;
         _v6Raw = null;
         _v6Typed = null;
 
@@ -57,6 +60,9 @@ public class AsyncSqsBenchmarks
 
     [Benchmark]
     public Task<int> V5TypedAsync() => _v5Typed!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6MinimalAsync() => _v6Minimal!.InvokeAsync(BatchSize);
 
     [Benchmark]
     public Task<int> V6RawAsync() => _v6Raw!.InvokeAsync(BatchSize);

--- a/benchmarks/Benchmarks/NestedAsyncSqsSnsS3Benchmarks.cs
+++ b/benchmarks/Benchmarks/NestedAsyncSqsSnsS3Benchmarks.cs
@@ -16,6 +16,7 @@ public class NestedAsyncSqsSnsS3Benchmarks
     private TargetSession? _v6Session;
     private ISqsTarget? _rawSdk;
     private ISqsTarget? _v5;
+    private ISqsTarget? _v6Minimal;
     private ISqsTarget? _v6;
 
     [Params(1, 10)]
@@ -30,6 +31,7 @@ public class NestedAsyncSqsSnsS3Benchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.NestedAsyncSqsSnsS3Target");
         _v5 = _v5Session.CreateTarget<ISqsTarget>("V5Target.NestedAsyncSqsSnsS3Target");
+        _v6Minimal = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedAsyncMinimalSqsSnsS3Target");
         _v6 = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedAsyncSqsSnsS3Target");
     }
 
@@ -38,6 +40,7 @@ public class NestedAsyncSqsSnsS3Benchmarks
     {
         _rawSdk = null;
         _v5 = null;
+        _v6Minimal = null;
         _v6 = null;
 
         _rawSdkSession?.Dispose();
@@ -54,6 +57,9 @@ public class NestedAsyncSqsSnsS3Benchmarks
 
     [Benchmark]
     public Task<int> V5Async() => _v5!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6MinimalAsync() => _v6Minimal!.InvokeAsync(BatchSize);
 
     [Benchmark]
     public Task<int> V6Async() => _v6!.InvokeAsync(BatchSize);

--- a/benchmarks/Benchmarks/NestedSqsSnsS3Benchmarks.cs
+++ b/benchmarks/Benchmarks/NestedSqsSnsS3Benchmarks.cs
@@ -16,6 +16,7 @@ public class NestedSqsSnsS3Benchmarks
     private TargetSession? _v6Session;
     private ISqsTarget? _rawSdk;
     private ISqsTarget? _v5;
+    private ISqsTarget? _v6Minimal;
     private ISqsTarget? _v6;
 
     [Params(1, 10)]
@@ -30,6 +31,7 @@ public class NestedSqsSnsS3Benchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.NestedSqsSnsS3Target");
         _v5 = _v5Session.CreateTarget<ISqsTarget>("V5Target.NestedSqsSnsS3Target");
+        _v6Minimal = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedMinimalSqsSnsS3Target");
         _v6 = _v6Session.CreateTarget<ISqsTarget>("V6Target.NestedSqsSnsS3Target");
     }
 
@@ -38,6 +40,7 @@ public class NestedSqsSnsS3Benchmarks
     {
         _rawSdk = null;
         _v5 = null;
+        _v6Minimal = null;
         _v6 = null;
 
         _rawSdkSession?.Dispose();
@@ -54,6 +57,9 @@ public class NestedSqsSnsS3Benchmarks
 
     [Benchmark]
     public Task<int> V5() => _v5!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6Minimal() => _v6Minimal!.InvokeAsync(BatchSize);
 
     [Benchmark]
     public Task<int> V6() => _v6!.InvokeAsync(BatchSize);

--- a/benchmarks/Benchmarks/RequestBenchmarks.cs
+++ b/benchmarks/Benchmarks/RequestBenchmarks.cs
@@ -18,6 +18,7 @@ public class RequestBenchmarks
     private TargetSession? _v6Session;
     private IRequestTarget? _rawSdk;
     private IRequestTarget? _v5;
+    private IRequestTarget? _v6Minimal;
     private IRequestTarget? _v6;
 
     [GlobalSetup]
@@ -29,6 +30,7 @@ public class RequestBenchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<IRequestTarget>("RawSdkTarget.UppercaseTarget");
         _v5 = _v5Session.CreateTarget<IRequestTarget>("V5Target.UppercaseTarget");
+        _v6Minimal = _v6Session.CreateTarget<IRequestTarget>("V6Target.MinimalUppercaseTarget");
         _v6 = _v6Session.CreateTarget<IRequestTarget>("V6Target.UppercaseTarget");
     }
 
@@ -37,6 +39,7 @@ public class RequestBenchmarks
     {
         _rawSdk = null;
         _v5 = null;
+        _v6Minimal = null;
         _v6 = null;
 
         _rawSdkSession?.Dispose();
@@ -53,6 +56,9 @@ public class RequestBenchmarks
 
     [Benchmark]
     public Task<string> V5() => _v5!.InvokeAsync(Input);
+
+    [Benchmark]
+    public Task<string> V6Minimal() => _v6Minimal!.InvokeAsync(Input);
 
     [Benchmark]
     public Task<string> V6() => _v6!.InvokeAsync(Input);

--- a/benchmarks/Benchmarks/SqsBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsBenchmarks.cs
@@ -16,6 +16,7 @@ public class SqsBenchmarks
     private TargetSession? _v6Session;
     private ISqsTarget? _rawSdk;
     private ISqsTarget? _v5Typed;
+    private ISqsTarget? _v6Minimal;
     private ISqsTarget? _v6Raw;
     private ISqsTarget? _v6Typed;
 
@@ -31,6 +32,7 @@ public class SqsBenchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsTarget>("RawSdkTarget.UppercaseSqsTarget");
         _v5Typed = _v5Session.CreateTarget<ISqsTarget>("V5Target.UppercaseSqsTarget");
+        _v6Minimal = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseMinimalSqsTarget");
         _v6Raw = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseRawSqsTarget");
         _v6Typed = _v6Session.CreateTarget<ISqsTarget>("V6Target.UppercaseTypedSqsTarget");
     }
@@ -40,6 +42,7 @@ public class SqsBenchmarks
     {
         _rawSdk = null;
         _v5Typed = null;
+        _v6Minimal = null;
         _v6Raw = null;
         _v6Typed = null;
 
@@ -57,6 +60,9 @@ public class SqsBenchmarks
 
     [Benchmark]
     public Task<int> V5Typed() => _v5Typed!.InvokeAsync(BatchSize);
+
+    [Benchmark]
+    public Task<int> V6Minimal() => _v6Minimal!.InvokeAsync(BatchSize);
 
     [Benchmark]
     public Task<int> V6Raw() => _v6Raw!.InvokeAsync(BatchSize);

--- a/benchmarks/Benchmarks/SqsExceptionFailureBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsExceptionFailureBenchmarks.cs
@@ -17,6 +17,7 @@ public class SqsExceptionFailureBenchmarks
     private TargetSession? _v6Session;
     private ISqsFailureTarget? _rawSdk;
     private ISqsFailureTarget? _v5;
+    private ISqsFailureTarget? _v6Minimal;
     private ISqsFailureTarget? _v6Raw;
     private ISqsFailureTarget? _v6Typed;
 
@@ -32,11 +33,13 @@ public class SqsExceptionFailureBenchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsFailureTarget>("RawSdkTarget.FailureSqsTarget");
         _v5 = _v5Session.CreateTarget<ISqsFailureTarget>("V5Target.FailureSqsTarget");
+        _v6Minimal = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureMinimalSqsTarget");
         _v6Raw = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureRawSqsTarget");
         _v6Typed = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureTypedSqsTarget");
 
         ValidateTarget(_rawSdk, "RawSdk");
         ValidateTarget(_v5, "V5RequestResponse");
+        ValidateTarget(_v6Minimal, "V6Minimal");
         ValidateTarget(_v6Raw, "V6Raw");
         ValidateTarget(_v6Typed, "V6Typed");
     }
@@ -46,6 +49,7 @@ public class SqsExceptionFailureBenchmarks
     {
         _rawSdk = null;
         _v5 = null;
+        _v6Minimal = null;
         _v6Raw = null;
         _v6Typed = null;
 
@@ -65,6 +69,10 @@ public class SqsExceptionFailureBenchmarks
     [Benchmark]
     public Task<int> V5RequestResponseExceptionFailure() =>
         _v5!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
+
+    [Benchmark]
+    public Task<int> V6MinimalExceptionFailure() =>
+        _v6Minimal!.InvokeAsync(FailurePercent, SqsFailureMode.Exception);
 
     [Benchmark]
     public Task<int> V6RawExceptionFailure() =>

--- a/benchmarks/Benchmarks/SqsReturnedFailureBenchmarks.cs
+++ b/benchmarks/Benchmarks/SqsReturnedFailureBenchmarks.cs
@@ -17,6 +17,7 @@ public class SqsReturnedFailureBenchmarks
     private TargetSession? _v6Session;
     private ISqsFailureTarget? _rawSdk;
     private ISqsFailureTarget? _v5;
+    private ISqsFailureTarget? _v6Minimal;
     private ISqsFailureTarget? _v6Raw;
     private ISqsFailureTarget? _v6Typed;
 
@@ -32,11 +33,13 @@ public class SqsReturnedFailureBenchmarks
 
         _rawSdk = _rawSdkSession.CreateTarget<ISqsFailureTarget>("RawSdkTarget.FailureSqsTarget");
         _v5 = _v5Session.CreateTarget<ISqsFailureTarget>("V5Target.FailureSqsTarget");
+        _v6Minimal = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureMinimalSqsTarget");
         _v6Raw = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureRawSqsTarget");
         _v6Typed = _v6Session.CreateTarget<ISqsFailureTarget>("V6Target.FailureTypedSqsTarget");
 
         ValidateTarget(_rawSdk, "RawSdk");
         ValidateTarget(_v5, "V5RequestResponse");
+        ValidateTarget(_v6Minimal, "V6Minimal");
         ValidateTarget(_v6Raw, "V6Raw");
         ValidateTarget(_v6Typed, "V6Typed");
     }
@@ -46,6 +49,7 @@ public class SqsReturnedFailureBenchmarks
     {
         _rawSdk = null;
         _v5 = null;
+        _v6Minimal = null;
         _v6Raw = null;
         _v6Typed = null;
 
@@ -65,6 +69,10 @@ public class SqsReturnedFailureBenchmarks
     [Benchmark]
     public Task<int> V5RequestResponseReturnedFailure() =>
         _v5!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
+
+    [Benchmark]
+    public Task<int> V6MinimalReturnedFailure() =>
+        _v6Minimal!.InvokeAsync(FailurePercent, SqsFailureMode.ReturnedResult);
 
     [Benchmark]
     public Task<int> V6RawReturnedFailure() =>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ This directory contains performance benchmarks for the Lambda Template libraries
 - `BenchmarkWorkloads` contains dependency-free application workloads shared by every target.
 - `RawSdkTarget` implements the workloads as plain AWS Lambda handlers.
 - `V5Target` is pinned to the published v5 packages and keeps its original .NET 6 dependency graph isolated from the current source tree.
-- `V6Target` references the current projects under `src/` directly.
+- `V6Target` references the current projects under `src/` directly, including full and Minimal hosting contenders where an existing scenario can compare them directly.
 - `Benchmarks` contains the BenchmarkDotNet benchmark host and comparisons.
 
 The benchmark host loads the raw SDK, v5, and v6 targets through separate collectible `AssemblyLoadContext` instances and shares only the neutral `BenchmarkWorkloads` contract. Target loading happens during benchmark setup and is not part of the measured operation.
@@ -193,9 +193,16 @@ The request benchmark uses a trivial uppercase workload to compare:
 
 - a plain AWS Lambda handler (`RawSdk`), used as the BenchmarkDotNet baseline;
 - the published v5 runtime (`V5`);
-- the current v6 source tree (`V6`).
+- the current v6 Minimal request host (`V6Minimal`);
+- the current v6 full request host (`V6`).
+
+`V6Minimal` and `V6` use the same `UppercaseHandler` and the same v6 request/context contract. The only intentional difference is the host. This makes the contender useful for isolating the cost of the full invocation infrastructure from the cost of the v6 application programming model itself.
+
+The Minimal target still pays for the features deliberately retained by the lean host: function-local dependency injection, one async invocation scope, handler resolution, `RequestContext`, cancellation, and async scope disposal. The goal is therefore not to reproduce the raw SDK implementation byte-for-byte; the raw contender remains the lower-level reference point.
 
 The workload itself is shared so the comparison focuses on invocation-framework overhead rather than different application implementations.
+
+No separate Minimal benchmark family is created. Minimal hosting is added only as another contender in existing scenarios where the semantics and workload already allow a direct comparison.
 
 ### SQS functions
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,6 +76,8 @@ The benchmark-validation GitHub Actions workflow verifies the pinned SDK, builds
 
 This is the controlled-hardware V5 to V6 reference collected on 2026-08-20. The exact measured repository commit is `a94a87c669969c3f2784f8d460b7c090a441573e`.
 
+This reference was collected for beta 4 before Minimal hosting was added to the comparison. Every `V6` value in the tables below therefore refers to the **default/full V6 host measured at that commit**. These figures remain the historical V5-to-full-V6 baseline. `V6Minimal` is a later contender in the same Request benchmark and should be measured separately rather than retroactively inserted into this reference.
+
 ### Reference environment and method
 
 - Dell XPS 16 9640 with an Intel Core Ultra 9 185H (16 physical cores, 22 logical cores) and 63.46 GiB RAM;
@@ -93,7 +95,7 @@ Each primary comparison was then run three times as independent BenchmarkDotNet 
 
 Controlled local hardware is the source for these absolute comparisons. The GitHub-hosted benchmark history remains useful as release-to-release trend and canary data, but it is not an absolute performance baseline.
 
-Raw SDK is included as the lower-bound framework-cost reference. The primary migration comparison is V5 typed to V6 typed; Raw SDK parity is not a V6 performance requirement.
+Raw SDK is included as the lower-bound framework-cost reference. The primary migration comparison is V5 typed to the default/full V6 path; Raw SDK parity is not a V6 performance requirement.
 
 ### Request baseline
 
@@ -103,9 +105,9 @@ The request benchmark is intentionally trivial, so it exposes invocation-framewo
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Raw SDK | 19.73 ns | 128 B | 0.16x | 0.36x | 12.14% |
 | V5 | 123.18 ns | 352 B | 1.00x | 1.00x | 11.46% |
-| V6 | 676.35 ns | 1,672 B | 5.49x | 4.75x | 3.71% |
+| V6 full | 676.35 ns | 1,672 B | 5.49x | 4.75x | 3.71% |
 
-The relative increase is large because the workload itself does almost no work, while the median absolute difference remains below one microsecond. This benchmark is best read as the cost floor of the richer V6 request pipeline rather than as a prediction of end-to-end application latency.
+The relative increase is large because the workload itself does almost no work, while the median absolute difference remains below one microsecond. This benchmark is best read as the cost floor of the default/full V6 request host rather than as a prediction of end-to-end application latency.
 
 ### SQS framework-overhead floor
 
@@ -126,7 +128,7 @@ The synchronous SQS suite uses already-completed tasks/value tasks. It is the fr
 | 100 | V6 raw | 82.356 us | 108,912 B | 3.02x | 3.76x | 6.50% |
 | 100 | V6 typed | 99.051 us | 124,912 B | 3.63x | 4.31x | 8.74% |
 
-This is deliberately a framework-overhead benchmark. V6 performs substantially more work per record than V5, including record-scoped infrastructure and source-specific processing semantics, so this suite should not be used in isolation to drive optimization decisions.
+This is deliberately a framework-overhead benchmark. The default/source-specific V6 Record paths perform substantially more work per record than V5, including record-scoped infrastructure and source-specific processing semantics, so this suite should not be used in isolation to drive optimization decisions.
 
 ### Genuinely asynchronous SQS
 
@@ -145,9 +147,11 @@ The asynchronous SQS suite forces one real local suspension per record through `
 | 100 | Raw SDK | 57.945 us | 14,032 B | 0.70x | 0.35x | 7.75% |
 | 100 | V5 typed | 82.655 us | 39,832 B | 1.00x | 1.00x | 0.84% |
 | 100 | V6 raw | 227.757 us | 137,099 B | 2.76x | 3.44x | 10.37% |
+| 100 | V5 typed | 82.655 us | 39,832 B | 1.00x | 1.00x | 0.84% |
+| 100 | V6 raw | 227.757 us | 137,099 B | 2.76x | 3.44x | 10.37% |
 | 100 | V6 typed | 294.355 us | 161,069 B | 3.56x | 4.04x | 13.33% |
 
-Real suspension remains a more relevant guardrail for async-pipeline conclusions than the completed-task floor. The richer V6 record pipeline remains measurable in both time and allocations, but the batch-10 timing spread shows why these ratios should not be treated as universal throughput multipliers.
+Real suspension remains a more relevant guardrail for async-pipeline conclusions than the completed-task floor. The richer V6 Record pipeline remains measurable in both time and allocations, but the batch-10 timing spread shows why these ratios should not be treated as universal throughput multipliers.
 
 ### Cross-run stability
 
@@ -163,13 +167,13 @@ One refreshed batch-10 nested execution is included as context only, not as part
 | --- | ---: | ---: | ---: | ---: |
 | Raw SDK | 32.949 us | 38.95 KB | 62.110 us | 39.20 KB |
 | V5 | 35.816 us | 40.39 KB | 80.425 us | 42.18 KB |
-| V6 | 57.448 us | 61.12 KB | 193.772 us | 68.19 KB |
+| V6 full/source-specific | 57.448 us | 61.12 KB | 193.772 us | 68.19 KB |
 
-In this contextual run V6 is about 1.60x V5 synchronously and 2.41x V5 with a genuinely asynchronous leaf, while allocation is about 1.51x and 1.62x V5 respectively. The structural difference matters: V6 is performing source-specific S3 decoding/record processing and context propagation that remain application-owned in the Raw SDK and V5 implementations.
+In this contextual run the default/source-specific V6 path is about 1.60x V5 synchronously and 2.41x V5 with a genuinely asynchronous leaf, while allocation is about 1.51x and 1.62x V5 respectively. The structural difference matters: V6 is performing source-specific S3 decoding/record processing and context propagation that remain application-owned in the Raw SDK and V5 implementations.
 
 ### Interpreting the V6 cost
 
-V6 is a programming-model redesign rather than an optimization of the V5 execution path. The additional measured cost corresponds to capabilities that are intentionally part of the V6 model, including:
+The beta-4 reference measures the default/full V6 execution model rather than Minimal hosting. V6 is a programming-model redesign rather than an optimization of the V5 execution path. The additional measured cost corresponds to capabilities that are intentionally part of the measured V6 paths, including:
 
 - one independent DI scope per record with deterministic disposal;
 - source-specific immutable record contexts and access to raw/origin records;
@@ -179,9 +183,11 @@ V6 is a programming-model redesign rather than an optimization of the V5 executi
 - record-level telemetry seams;
 - reusable nested record processing and context propagation.
 
-Those features do not make every additional allocation unavoidable, and the benchmark suite remains the regression safety net for future implementation improvements. The important distinction is that V5 and V6 are not doing the same amount of framework work. The migration tradeoff is therefore not only throughput versus throughput: V6 moves more AWS event-processing policy and lifecycle behavior from application code into the framework.
+Those features do not make every additional allocation unavoidable, and the benchmark suite remains the regression safety net for future implementation improvements. The important distinction is that V5 and the measured default/full V6 paths are not doing the same amount of framework work. The migration tradeoff is therefore not only throughput versus throughput: V6 moves more AWS event-processing policy and lifecycle behavior from application code into the framework.
 
 The result-list sizing change was the low-risk avoidable allocation identified in the separate performance-hardening work. DI activation, async composition, no-listener telemetry short-circuit, and typed-handler fast-path candidates were also investigated, but did not justify production changes before beta 4.
+
+Minimal hosting should not be interpreted as correcting those semantics. It adds a smaller Request/Event hosting choice for functions that do not need the full host-level behavior. A new controlled run including `V6Minimal` can therefore extend this analysis by isolating the cost of the full Request host from the v6 handler/context/DI model retained by Minimal, while leaving the beta-4 baseline intact.
 
 For performance-sensitive migrations, read synchronous and genuinely asynchronous results together, pay close attention to allocations, and validate the actual workload.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -147,8 +147,6 @@ The asynchronous SQS suite forces one real local suspension per record through `
 | 100 | Raw SDK | 57.945 us | 14,032 B | 0.70x | 0.35x | 7.75% |
 | 100 | V5 typed | 82.655 us | 39,832 B | 1.00x | 1.00x | 0.84% |
 | 100 | V6 raw | 227.757 us | 137,099 B | 2.76x | 3.44x | 10.37% |
-| 100 | V5 typed | 82.655 us | 39,832 B | 1.00x | 1.00x | 0.84% |
-| 100 | V6 raw | 227.757 us | 137,099 B | 2.76x | 3.44x | 10.37% |
 | 100 | V6 typed | 294.355 us | 161,069 B | 3.56x | 4.04x | 13.33% |
 
 Real suspension remains a more relevant guardrail for async-pipeline conclusions than the completed-task floor. The richer V6 Record pipeline remains measurable in both time and allocations, but the batch-10 timing spread shows why these ratios should not be treated as universal throughput multipliers.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -76,7 +76,7 @@ The benchmark-validation GitHub Actions workflow verifies the pinned SDK, builds
 
 This is the controlled-hardware V5 to V6 reference collected on 2026-08-20. The exact measured repository commit is `a94a87c669969c3f2784f8d460b7c090a441573e`.
 
-This reference was collected for beta 4 before Minimal hosting was added to the comparison. Every `V6` value in the tables below therefore refers to the **default/full V6 host measured at that commit**. These figures remain the historical V5-to-full-V6 baseline. `V6Minimal` is a later contender in the same Request benchmark and should be measured separately rather than retroactively inserted into this reference.
+This reference was collected for beta 4 before Minimal hosting was added to the comparison. Every `V6` value in the tables below therefore refers to the **default/full V6 host measured at that commit**. These figures remain the historical V5-to-full-V6 baseline. `V6Minimal` was added later as a contender in the Request suite and, for comparison purposes, as a benchmark-only application composition in the SQS, failure, and nested suites. Those new contenders must be measured separately rather than retroactively inserted into this reference.
 
 ### Reference environment and method
 
@@ -185,7 +185,7 @@ Those features do not make every additional allocation unavoidable, and the benc
 
 The result-list sizing change was the low-risk avoidable allocation identified in the separate performance-hardening work. DI activation, async composition, no-listener telemetry short-circuit, and typed-handler fast-path candidates were also investigated, but did not justify production changes before beta 4.
 
-Minimal hosting should not be interpreted as correcting those semantics. It adds a smaller Request/Event hosting choice for functions that do not need the full host-level behavior. A new controlled run including `V6Minimal` can therefore extend this analysis by isolating the cost of the full Request host from the v6 handler/context/DI model retained by Minimal, while leaving the beta-4 baseline intact.
+Minimal hosting should not be interpreted as correcting those semantics. It adds a smaller Request/Event hosting choice. In the Request suite, `V6Minimal` isolates the full Request host from the v6 handler/context/DI model retained by Minimal. In the SQS, failure, and nested suites, the benchmark-only `V6Minimal` contender deliberately moves AWS-specific iteration, decoding, failure translation, and nested envelope processing back into application code while retaining the Minimal host. This allows a new controlled run to measure the cost boundary between lean KLT hosting and framework-owned AWS orchestration without changing the beta-4 reference.
 
 For performance-sensitive migrations, read synchronous and genuinely asynchronous results together, pay close attention to allocations, and validate the actual workload.
 
@@ -214,8 +214,11 @@ The synchronous SQS benchmark measures batches of 1, 10, and 100 records and com
 
 - a plain AWS Lambda SQS handler (`RawSdk`), used as the BenchmarkDotNet baseline;
 - the published v5 typed SQS function (`V5Typed`);
+- a benchmark-only `MinimalRequestFunction<SQSEvent, SQSBatchResponse, ...>` composition where application code owns SQS iteration, JSON decoding, and response construction (`V6Minimal`);
 - the current v6 raw SQS function (`V6Raw`);
 - the current v6 typed SQS function (`V6Typed`).
+
+`V6Minimal` is not a `MinimalSqsFunction` product API. It deliberately uses the source-neutral Minimal request host and places the SQS-specific mechanics in the benchmark handler. The comparison therefore shows what happens when the application retains the Minimal host's configuration, dependency injection, invocation scope, context, cancellation, and async disposal while taking back the event-source orchestration supplied by the full/source-specific V6 path.
 
 Every target receives an equivalent pre-built SQS envelope. Envelope construction and target loading happen during benchmark setup so the measured operation focuses on dispatch, decoding, record handling, and response construction.
 
@@ -223,7 +226,7 @@ The synchronous handlers return already-completed tasks/value tasks. That makes 
 
 ### Asynchronous SQS functions
 
-`AsyncSqsBenchmarks` repeats the same Raw SDK, v5, v6 raw, and v6 typed comparison while forcing one real asynchronous suspension per record using the shared `AsyncWorkload.Suspend()` helper.
+`AsyncSqsBenchmarks` repeats the Raw SDK, V5 typed, V6 Minimal, V6 raw, and V6 typed comparison while forcing one real asynchronous suspension per record using the shared `AsyncWorkload.Suspend()` helper. In `V6Minimal`, that suspension occurs inside the application-owned SQS loop; in the source-specific V6 contenders it occurs in the record handler invoked by the framework pipeline.
 
 The helper returns `Task.Yield()` directly so the benchmark remains deterministic, local, and independent of network or service latency without adding a separate helper task state machine. It models the control-flow and allocation effects of a handler that actually suspends; it does not attempt to model DynamoDB, S3, HTTP, or other I/O latency.
 
@@ -237,9 +240,11 @@ The failure benchmarks use a fixed batch of 10 records and cover deterministic 0
 
 The Raw SDK target contains the hand-written record loop and failure collection needed to implement those semantics directly. V5 is also included, but its published SQS module has no per-record partial-batch result contract. The V5 benchmark therefore uses `RequestResponseFunction<SQSEvent, SQSBatchResponse>` and implements JSON decoding, record iteration, per-record exception handling, and response construction in the consumer handler. This is intentionally the realistic V5 route to obtain the same AWS behavior rather than inventing a V6-style abstraction inside the old SQS module.
 
-V6 measures both raw and typed record handlers and uses its built-in record-result and exception-translation pipeline. The comparison therefore captures not only runtime cost but also where the partial-batch plumbing lives in each programming model.
+`V6Minimal` follows the same fairness principle. It uses `MinimalRequestFunction<SQSEvent, SQSBatchResponse, ...>` and keeps partial-batch policy in application code. The returned-result variant collects failed message IDs directly. The exception variant deliberately throws for failed records, catches those exceptions inside the application-owned record loop, and translates them into the same `SQSBatchResponse`.
 
-The V6 exception benchmark functions clear logging providers so repeated BenchmarkDotNet invocations do not flood stdout with one error message per failed record. Exception handling and translation still run through the normal framework path, but provider output cost is intentionally excluded from this suite.
+`V6Raw` and `V6Typed` instead use the built-in V6 record-result and exception-translation pipeline. The comparison therefore captures not only runtime cost but also where the partial-batch plumbing lives in each programming model and hosting choice.
+
+The V6 source-specific exception benchmark functions clear logging providers so repeated BenchmarkDotNet invocations do not flood stdout with one error message per failed record. Exception handling and translation still run through the normal framework path, but provider output cost is intentionally excluded from this suite.
 
 The failure matrix remains synchronously completed to isolate the incremental cost of partial-batch handling and exception translation. The separate asynchronous SQS suite covers genuine suspension without multiplying every failure percentage by another completion-mode dimension.
 
@@ -251,12 +256,15 @@ The suites use batches of 1 and 10 SQS messages and compare:
 
 - a Raw SDK implementation that owns SQS iteration, SNS-envelope decoding, S3-event decoding, and S3-record iteration directly;
 - a V5 implementation that uses the V5 typed SQS message handler for the outer SNS envelope, while application code still owns S3-event decoding and S3-record iteration;
-- a V6 implementation that follows the recommended nested flow: typed SQS handling for the SNS envelope, an S3 decoder, and the reusable S3 record processor/handler pipeline.
+- a benchmark-only V6 Minimal composition where `MinimalRequestFunction<SQSEvent, SQSBatchResponse, ...>` supplies the lean host and application code owns SQS iteration, SNS decoding, S3 decoding, and S3-record iteration;
+- a full/source-specific V6 implementation that follows the recommended nested flow: typed SQS handling for the SNS envelope, an S3 decoder, and the reusable S3 record processor/handler pipeline.
 
-The Raw SDK and V5 implementations use case-insensitive `System.Text.Json` options when manually decoding the canonical AWS S3 event JSON, matching the lowercase AWS property names without changing the shared fixture.
+The Raw SDK, V5, and V6 Minimal implementations use case-insensitive `System.Text.Json` options when manually decoding the canonical AWS S3 event JSON, matching the lowercase AWS property names without changing the shared fixture.
 
-`NestedSqsSnsS3Benchmarks` uses a synchronously completed S3 leaf handler. `NestedAsyncSqsSnsS3Benchmarks` uses the same deterministic `Task.Yield()` suspension at the S3 leaf so the nested pipeline is also measured when application work genuinely suspends.
+`NestedSqsSnsS3Benchmarks` uses a synchronously completed S3 leaf workload. `NestedAsyncSqsSnsS3Benchmarks` uses the same deterministic `Task.Yield()` suspension at the S3 leaf so the nested pipeline is also measured when application work genuinely suspends. For `V6Minimal`, that leaf remains inside the application-owned nested loop; for full V6 it runs through the reusable S3 record processor.
 
-The V6 leaf handler also reads the originating raw SQS message from the propagated S3 record context. This exercises one of the context-propagation capabilities provided by the V6 record model rather than treating the extra pipeline solely as dispatch overhead.
+The full V6 leaf handler also reads the originating raw SQS message from the propagated S3 record context. This exercises one of the context-propagation capabilities provided by the V6 record model rather than treating the extra pipeline solely as dispatch overhead.
 
-The runtime numbers should be read together with the structural difference between implementations. Raw SDK owns all envelope plumbing. V5 removes the outer SQS decoding but still leaves nested S3 parsing/iteration in application code. V6 supplies the source-specific S3 decoder/processor and context propagation, at the cost of the additional framework machinery those capabilities require.
+The runtime numbers should be read together with the structural difference between implementations. Raw SDK owns all hosting and envelope plumbing. V6 Minimal keeps KLT's lean host but owns all AWS-specific nested orchestration in application code. V5 removes the outer SQS decoding while leaving nested S3 parsing/iteration in application code. Full/source-specific V6 supplies the source-specific S3 decoder/processor and context propagation. The resulting spectrum is intended to show both runtime cost and the amount of infrastructure responsibility moved from application code into the framework.
+
+The benchmark-only Minimal SQS compositions do not change the V6.0 product boundary: there is still no `MinimalSqsFunction`, `MinimalSnsFunction`, `MinimalS3Function`, or other source-specific Minimal host.

--- a/benchmarks/V6Target/NestedSqsSnsS3Target.cs
+++ b/benchmarks/V6Target/NestedSqsSnsS3Target.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,9 +20,41 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace V6Target;
 
+public sealed class NestedMinimalSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedMinimalSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
 public sealed class NestedSqsSnsS3Target : ISqsTarget
 {
     private readonly NestedSqsSnsS3Function _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = NestedSqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedAsyncMinimalSqsSnsS3Target : ISqsTarget
+{
+    private readonly NestedAsyncMinimalSqsSnsS3Function _function = new();
     private readonly ILambdaContext _context = new TestLambdaContext
     {
         RemainingTime = TimeSpan.FromMinutes(1)
@@ -48,6 +81,76 @@ public sealed class NestedAsyncSqsSnsS3Target : ISqsTarget
     {
         var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
         return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class NestedMinimalSqsSnsS3Function : MinimalRequestFunction<SQSEvent, SQSBatchResponse, NestedMinimalSqsSnsS3Handler>;
+
+public sealed class NestedMinimalSqsSnsS3Handler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var sqsRecord in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var snsEnvelope = JsonSerializer.Deserialize<NestedSnsEnvelope>(sqsRecord.Body, NestedMinimalJson.Options)
+                ?? throw new JsonException("The benchmark SNS envelope could not be deserialized.");
+            var s3Event = JsonSerializer.Deserialize<S3Event>(snsEnvelope.Message, NestedMinimalJson.Options)
+                ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit Minimal S3 record loop so the benchmark does not add LINQ allocations.
+            foreach (var s3Record in s3Event.Records ?? [])
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+            }
+#pragma warning restore S3267
+        }
+
+        return ValueTask.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        });
+    }
+}
+
+public sealed class NestedAsyncMinimalSqsSnsS3Function : MinimalRequestFunction<SQSEvent, SQSBatchResponse, NestedAsyncMinimalSqsSnsS3Handler>;
+
+public sealed class NestedAsyncMinimalSqsSnsS3Handler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public async ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var sqsRecord in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var snsEnvelope = JsonSerializer.Deserialize<NestedSnsEnvelope>(sqsRecord.Body, NestedMinimalJson.Options)
+                ?? throw new JsonException("The benchmark SNS envelope could not be deserialized.");
+            var s3Event = JsonSerializer.Deserialize<S3Event>(snsEnvelope.Message, NestedMinimalJson.Options)
+                ?? throw new JsonException("The benchmark S3 event payload could not be deserialized.");
+
+#pragma warning disable S3267 // Preserve the explicit async Minimal S3 record loop so the benchmark does not add LINQ allocations.
+            foreach (var s3Record in s3Event.Records ?? [])
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await AsyncWorkload.Suspend();
+                cancellationToken.ThrowIfCancellationRequested();
+                _ = NestedSqsSnsS3Workload.Execute(s3Record.S3.Bucket.Name, s3Record.S3.Object.Key);
+            }
+#pragma warning restore S3267
+        }
+
+        return new SQSBatchResponse
+        {
+            BatchItemFailures = []
+        };
     }
 }
 
@@ -133,6 +236,14 @@ public sealed class NestedAsyncS3ObjectEventHandler : IS3ObjectEventHandler
         await AsyncWorkload.Suspend();
         _ = NestedSqsSnsS3Workload.Execute(item.Object.Bucket, item.Object.Key);
     }
+}
+
+internal static class NestedMinimalJson
+{
+    public static JsonSerializerOptions Options { get; } = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
 }
 
 internal static class NestedSqsEnvelopeFactory

--- a/benchmarks/V6Target/SqsFailureTarget.cs
+++ b/benchmarks/V6Target/SqsFailureTarget.cs
@@ -17,6 +17,29 @@ using Microsoft.Extensions.Logging;
 
 namespace V6Target;
 
+public sealed class FailureMinimalSqsTarget : ISqsFailureTarget
+{
+    private readonly ReturnedFailureMinimalSqsFunction _returnedFunction = new();
+    private readonly ExceptionFailureMinimalSqsFunction _exceptionFunction = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsFailureEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int failurePercent, SqsFailureMode mode)
+    {
+        var response = mode switch
+        {
+            SqsFailureMode.ReturnedResult => await _returnedFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            SqsFailureMode.Exception => await _exceptionFunction.FunctionHandlerAsync(_events[failurePercent], _context).ConfigureAwait(false),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
 public sealed class FailureRawSqsTarget : ISqsFailureTarget
 {
     private readonly ReturnedFailureRawSqsFunction _returnedFunction = new();
@@ -60,6 +83,83 @@ public sealed class FailureTypedSqsTarget : ISqsFailureTarget
         };
 
         return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class ReturnedFailureMinimalSqsFunction : MinimalRequestFunction<SQSEvent, SQSBatchResponse, ReturnedFailureMinimalSqsHandler>;
+
+public sealed class ReturnedFailureMinimalSqsHandler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+                ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+            _ = SqsFailureWorkload.Execute(message);
+
+            if (message.ShouldFail)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure
+                {
+                    ItemIdentifier = record.MessageId
+                });
+            }
+        }
+
+        return ValueTask.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = failures
+        });
+    }
+}
+
+public sealed class ExceptionFailureMinimalSqsFunction : MinimalRequestFunction<SQSEvent, SQSBatchResponse, ExceptionFailureMinimalSqsHandler>;
+
+public sealed class ExceptionFailureMinimalSqsHandler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        var failures = new List<SQSBatchResponse.BatchItemFailure>();
+
+        foreach (var record in input.Records ?? Enumerable.Empty<SQSEvent.SQSMessage>())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var message = JsonSerializer.Deserialize<SqsFailureBenchmarkMessage>(record.Body)
+                    ?? throw new JsonException("The benchmark SQS message could not be deserialized.");
+                _ = SqsFailureWorkload.Execute(message);
+
+                if (message.ShouldFail)
+                {
+                    throw new InvalidOperationException("benchmark failure");
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                failures.Add(new SQSBatchResponse.BatchItemFailure
+                {
+                    ItemIdentifier = record.MessageId
+                });
+            }
+        }
+
+        return ValueTask.FromResult(new SQSBatchResponse
+        {
+            BatchItemFailures = failures
+        });
     }
 }
 

--- a/benchmarks/V6Target/SqsTarget.cs
+++ b/benchmarks/V6Target/SqsTarget.cs
@@ -15,6 +15,22 @@ using Kralizek.Lambda;
 
 namespace V6Target;
 
+public sealed class UppercaseMinimalSqsTarget : ISqsTarget
+{
+    private readonly UppercaseMinimalSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
 public sealed class UppercaseRawSqsTarget : ISqsTarget
 {
     private readonly UppercaseRawSqsFunction _function = new();
@@ -34,6 +50,22 @@ public sealed class UppercaseRawSqsTarget : ISqsTarget
 public sealed class UppercaseTypedSqsTarget : ISqsTarget
 {
     private readonly UppercaseTypedSqsFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+    private readonly IReadOnlyDictionary<int, SQSEvent> _events = SqsEnvelopeFactory.Create();
+
+    public async Task<int> InvokeAsync(int batchSize)
+    {
+        var response = await _function.FunctionHandlerAsync(_events[batchSize], _context).ConfigureAwait(false);
+        return response.BatchItemFailures?.Count ?? 0;
+    }
+}
+
+public sealed class UppercaseAsyncMinimalSqsTarget : ISqsTarget
+{
+    private readonly UppercaseAsyncMinimalSqsFunction _function = new();
     private readonly ILambdaContext _context = new TestLambdaContext
     {
         RemainingTime = TimeSpan.FromMinutes(1)
@@ -79,6 +111,27 @@ public sealed class UppercaseAsyncTypedSqsTarget : ISqsTarget
     }
 }
 
+public sealed class UppercaseMinimalSqsFunction : MinimalRequestFunction<SQSEvent, SQSBatchResponse, UppercaseMinimalSqsHandler>;
+
+public sealed class UppercaseMinimalSqsHandler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var record in input.Records ?? [])
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+            _ = SqsWorkload.Execute(message);
+        }
+
+        return ValueTask.FromResult(new SQSBatchResponse());
+    }
+}
+
 public sealed class UppercaseRawSqsFunction : SqsFunction<UppercaseRawSqsHandler>;
 
 public sealed class UppercaseRawSqsHandler : ISqsRecordHandler
@@ -111,6 +164,30 @@ public sealed class UppercaseTypedSqsHandler : ISqsMessageHandler<SqsBenchmarkMe
         _ = SqsWorkload.Execute(message);
 
         return ValueTask.FromResult(SqsRecordResult.Success);
+    }
+}
+
+public sealed class UppercaseAsyncMinimalSqsFunction : MinimalRequestFunction<SQSEvent, SQSBatchResponse, UppercaseAsyncMinimalSqsHandler>;
+
+public sealed class UppercaseAsyncMinimalSqsHandler : IRequestHandler<SQSEvent, SQSBatchResponse>
+{
+    public async ValueTask<SQSBatchResponse> HandleAsync(
+        SQSEvent input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+    {
+        foreach (var record in input.Records ?? [])
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await AsyncWorkload.Suspend();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var message = JsonSerializer.Deserialize<SqsBenchmarkMessage>(record.Body)!;
+            _ = SqsWorkload.Execute(message);
+        }
+
+        return new SQSBatchResponse();
     }
 }
 

--- a/benchmarks/V6Target/UppercaseTarget.cs
+++ b/benchmarks/V6Target/UppercaseTarget.cs
@@ -22,7 +22,20 @@ public sealed class UppercaseTarget : IRequestTarget
     public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, _context);
 }
 
+public sealed class MinimalUppercaseTarget : IRequestTarget
+{
+    private readonly MinimalUppercaseFunction _function = new();
+    private readonly ILambdaContext _context = new TestLambdaContext
+    {
+        RemainingTime = TimeSpan.FromMinutes(1)
+    };
+
+    public Task<string> InvokeAsync(string input) => _function.FunctionHandlerAsync(input, _context);
+}
+
 public sealed class UppercaseFunction : RequestFunction<string, string, UppercaseHandler>;
+
+public sealed class MinimalUppercaseFunction : MinimalRequestFunction<string, string, UppercaseHandler>;
 
 public sealed class UppercaseHandler : IRequestHandler<string, string>
 {

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -13,7 +13,7 @@ The main conceptual changes are:
 
 V6 also separates the request/event handler programming model from the amount of hosting infrastructure used to invoke it. `EventFunction` and `RequestFunction` remain the default/full hosts. `MinimalEventFunction` and `MinimalRequestFunction` invoke the same v6 handlers through a leaner path that retains configuration, logging, function-local dependency injection, one invocation scope, the v6 context, cancellation, and asynchronous scope disposal.
 
-This can be particularly relevant when migrating a simple v5 Event or Request/Response function. V5 already provided a function-local service provider and one DI scope per invocation with comparatively little runtime overhead. If the migrated function does not need v6 record processing, source-specific orchestration, or internal framework telemetry, consider the Minimal host after moving the application logic to the v6 handler contract.
+This can be particularly relevant when migrating a simple v5 Event or Request/Response function. V5 already provided a function-local service provider and one DI scope per invocation with comparatively little runtime overhead. If the migrated function does not need the full Request/Event host's internal invocation telemetry or any source-specific record-processing behavior, consider the Minimal host after moving the application logic to the v6 handler contract.
 
 For example, once a request handler has been migrated to v6, choosing the lean host is only a hosting change:
 
@@ -29,16 +29,18 @@ public class Function : MinimalRequestFunction<string, string, MyHandler>;
 
 The handler remains unchanged. See [Minimal Hosting](Minimal-Hosting.md) for the exact capability boundary.
 
-For a migration, first identify the invocation semantics, select the matching v6 template/package, move application behavior into the new handler contract, and then restore any custom service registration, decoding, or source-specific failure behavior. Choose Minimal only after determining that the function does not rely on behavior deliberately owned by the full/source-specific host.
+For a migration, first identify the invocation semantics, select the matching v6 template/package, move application behavior into the new handler contract, and then restore any custom service registration, decoding, or source-specific failure behavior. Choose Minimal only after determining that the function does not rely on behavior deliberately owned by the full Request/Event host or by a source-specific Record host.
 
 Because the redesign changes public base classes and handler contracts, migrate and test one Lambda integration at a time rather than attempting a mechanical namespace/package replacement.
 
 ## Performance
 
-V6 also changes the execution model, so consumers should expect measurable runtime and allocation overhead compared with V5. The magnitude depends heavily on workload shape: synchronous microbenchmarks expose the framework floor, while genuinely asynchronous workloads give a more relevant view of async pipelines. V6 remains measurably more expensive in both, but exact ratios should not be generalized to every function.
+The controlled reference published for beta 4 measured V5 against the **default/full V6 hosting model**. It established that full V6 has measurable runtime and allocation overhead compared with V5. The magnitude depends heavily on workload shape: synchronous microbenchmarks expose the framework floor, while genuinely asynchronous workloads give a more relevant view of async pipelines. Exact ratios should not be generalized to every function.
 
-That additional cost should be evaluated together with the semantics V6 provides: one independent DI scope per record, source-specific immutable contexts, raw/origin record access, partial-batch result handling, automatic exception translation, cancellation and disposal guarantees, telemetry seams, and reusable nested record processing.
+That beta-4 comparison should be read together with the semantics the measured V6 paths provide. For record-oriented integrations those include one independent DI scope per record, source-specific immutable contexts, raw/origin record access, partial-batch result handling, automatic exception translation, cancellation and disposal guarantees, telemetry seams, and reusable nested record processing. The additional work is therefore not simply implementation waste, and not every additional allocation is a defect.
 
-For source-neutral request/event functions that do not need the richer processing path, Minimal hosting is the explicit v6 option for retaining the same handler/context/DI model while reducing framework involvement. It should be evaluated with the same workload-specific discipline rather than treated as raw-SDK compatibility.
+Minimal hosting does not invalidate that reference or replace the default host. It adds a second hosting choice for source-neutral Request/Event functions. When a function does not need the full host's internal invocation telemetry or source-specific Record processing, Minimal retains the same v6 handler/context/DI model while deliberately reducing framework involvement. It should be evaluated as a smaller capability set, not as a compatibility mode or a claim that the full V6 model was incorrect.
+
+The original beta-4 figures remain the controlled V5-to-full-V6 baseline. New measurements that include Minimal should be treated as an additional comparison showing how much of the Request/Event overhead belongs to the full hosting path versus the v6 handler/context model retained by Minimal.
 
 Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md#controlled-v5-to-v6-reference) for the controlled-hardware methodology, repeated-run values, allocations, stability spread, and the distinction between synchronous framework-overhead and genuinely asynchronous workloads.

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -11,7 +11,25 @@ The main conceptual changes are:
 - Framework contexts expose common Lambda metadata without requiring handlers to depend directly on `ILambdaContext`; the original AWS context remains available as an escape hatch.
 - Record processing owns one DI scope per record, with parallel processing exposed only by integrations where it is appropriate.
 
-For a migration, first identify the invocation semantics, select the matching v6 template/package, move application behavior into the new handler contract, and then restore any custom service registration, decoding, or source-specific failure behavior.
+V6 also separates the request/event handler programming model from the amount of hosting infrastructure used to invoke it. `EventFunction` and `RequestFunction` remain the default/full hosts. `MinimalEventFunction` and `MinimalRequestFunction` invoke the same v6 handlers through a leaner path that retains configuration, logging, function-local dependency injection, one invocation scope, the v6 context, cancellation, and asynchronous scope disposal.
+
+This can be particularly relevant when migrating a simple v5 Event or Request/Response function. V5 already provided a function-local service provider and one DI scope per invocation with comparatively little runtime overhead. If the migrated function does not need v6 record processing, source-specific orchestration, or internal framework telemetry, consider the Minimal host after moving the application logic to the v6 handler contract.
+
+For example, once a request handler has been migrated to v6, choosing the lean host is only a hosting change:
+
+```csharp
+public class Function : RequestFunction<string, string, MyHandler>;
+```
+
+becomes:
+
+```csharp
+public class Function : MinimalRequestFunction<string, string, MyHandler>;
+```
+
+The handler remains unchanged. See [Minimal Hosting](Minimal-Hosting.md) for the exact capability boundary.
+
+For a migration, first identify the invocation semantics, select the matching v6 template/package, move application behavior into the new handler contract, and then restore any custom service registration, decoding, or source-specific failure behavior. Choose Minimal only after determining that the function does not rely on behavior deliberately owned by the full/source-specific host.
 
 Because the redesign changes public base classes and handler contracts, migrate and test one Lambda integration at a time rather than attempting a mechanical namespace/package replacement.
 
@@ -20,5 +38,7 @@ Because the redesign changes public base classes and handler contracts, migrate 
 V6 also changes the execution model, so consumers should expect measurable runtime and allocation overhead compared with V5. The magnitude depends heavily on workload shape: synchronous microbenchmarks expose the framework floor, while genuinely asynchronous workloads give a more relevant view of async pipelines. V6 remains measurably more expensive in both, but exact ratios should not be generalized to every function.
 
 That additional cost should be evaluated together with the semantics V6 provides: one independent DI scope per record, source-specific immutable contexts, raw/origin record access, partial-batch result handling, automatic exception translation, cancellation and disposal guarantees, telemetry seams, and reusable nested record processing.
+
+For source-neutral request/event functions that do not need the richer processing path, Minimal hosting is the explicit v6 option for retaining the same handler/context/DI model while reducing framework involvement. It should be evaluated with the same workload-specific discipline rather than treated as raw-SDK compatibility.
 
 Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md#controlled-v5-to-v6-reference) for the controlled-hardware methodology, repeated-run values, allocations, stability spread, and the distinction between synchronous framework-overhead and genuinely asynchronous workloads.

--- a/docs/Minimal-Hosting.md
+++ b/docs/Minimal-Hosting.md
@@ -2,7 +2,7 @@
 
 Version 6 has one request/event handler programming model and two hosting choices.
 
-The normal `EventFunction` and `RequestFunction` hosts provide the complete v6 invocation infrastructure. `MinimalEventFunction` and `MinimalRequestFunction` host the same handlers through a deliberately shorter execution path when the function does not need the richer processing pipeline.
+The normal `EventFunction` and `RequestFunction` hosts provide the complete v6 Request/Event invocation infrastructure. `MinimalEventFunction` and `MinimalRequestFunction` host the same handlers through a deliberately shorter execution path when the function does not need all of that host-level infrastructure.
 
 Minimal hosting is a hosting choice, not a second application programming model. For supported request/event functions, the handler contract and application code stay the same:
 
@@ -36,18 +36,27 @@ This is intentionally similar to the useful infrastructure that v5 could provide
 
 ## What minimal hosting omits
 
-The minimal host does not execute the normal host's internal invocation telemetry or richer processing pipeline. In particular it does not provide:
+For Request/Event functions, Minimal does not execute the default/full host's internal invocation telemetry path. In particular, Minimal does not emit Kralizek.Lambda.Template `ActivitySource` activities or `Meter` instruments for the invocation.
 
-- Kralizek.Lambda.Template `ActivitySource` activities or `Meter` instruments;
-- record processing or per-record result semantics;
+Separately, Minimal hosting in v6.0 does not extend to source-specific Record hosts. Therefore it also does not provide the source-specific Record-processing capabilities owned by those hosts, such as:
+
+- per-record processing and source-specific result semantics;
 - source-specific envelope orchestration;
 - partial-batch response translation;
 - nested record-context propagation;
 - source-specific record processors.
 
-Those capabilities remain part of the normal/source-specific v6 hosts.
+Those Record capabilities are not being removed from `EventFunction` or `RequestFunction`; they belong to the source-specific Record model and remain available through the normal source-specific hosts.
 
 There are intentionally no `MinimalSqsFunction`, `MinimalSnsFunction`, `MinimalS3Function`, or equivalent source-specific Minimal types in v6.0.
+
+## Relationship to the beta-4 performance baseline
+
+The controlled V5-to-V6 reference published for beta 4 measured the default/full V6 paths before Minimal hosting was part of the comparison. That reference remains valid and should continue to be read as the cost of the default/full V6 execution model on the measured workloads.
+
+Minimal does not "fix" that baseline or imply that the richer V6 behavior was accidental. Instead, it gives source-neutral Request/Event functions a smaller hosting capability set when they do not need the full host's internal invocation telemetry or any source-specific Record-processing behavior.
+
+A benchmark that adds `V6Minimal` to the existing Request scenario therefore answers a narrower question: how much of the measured Request overhead belongs to the full hosting path, and how much belongs to the v6 handler/context/DI model that Minimal deliberately retains.
 
 ## OpenTelemetry
 
@@ -93,8 +102,8 @@ For these templates, switching between the normal and Minimal host changes `Func
 
 ## Choosing the host
 
-Prefer the normal host when the function uses source-specific processing semantics, record processing, framework telemetry, or other behavior provided by the full v6 pipeline.
+Prefer the normal Request/Event host when the function wants the full host's invocation infrastructure, including KLT internal invocation telemetry. Prefer the normal source-specific Record hosts when the function needs record processing, result/failure semantics, envelope orchestration, context propagation, or other source-specific behavior.
 
-Prefer Minimal for source-neutral request/event functions where the application wants the v6 handler/context/DI model but does not need that additional orchestration and wants invocation overhead closer to the raw Lambda runtime.
+Prefer Minimal for source-neutral request/event functions where the application wants the v6 handler/context/DI model but does not need that additional host-level behavior and wants lower invocation overhead.
 
 The normal host remains the default. Minimal is an explicit performance-oriented trade-off, not a compatibility mode.

--- a/docs/Minimal-Hosting.md
+++ b/docs/Minimal-Hosting.md
@@ -1,0 +1,100 @@
+# Minimal hosting
+
+Version 6 has one request/event handler programming model and two hosting choices.
+
+The normal `EventFunction` and `RequestFunction` hosts provide the complete v6 invocation infrastructure. `MinimalEventFunction` and `MinimalRequestFunction` host the same handlers through a deliberately shorter execution path when the function does not need the richer processing pipeline.
+
+Minimal hosting is a hosting choice, not a second application programming model. For supported request/event functions, the handler contract and application code stay the same:
+
+```csharp
+public class Function : RequestFunction<string, string, UpperCaseHandler>;
+```
+
+can become:
+
+```csharp
+public class Function : MinimalRequestFunction<string, string, UpperCaseHandler>;
+```
+
+without changing `UpperCaseHandler`.
+
+## What minimal hosting keeps
+
+Minimal hosting deliberately spends a small amount of runtime overhead on application structure that remains useful even for simple Lambda functions:
+
+- function-local configuration;
+- function-local dependency injection;
+- Lambda-compatible logging and application logging configuration;
+- one dependency-injection scope per invocation;
+- handler activation through the invocation scope;
+- the same `EventContext` / `RequestContext` contracts as the normal host;
+- the original `ILambdaContext` escape hatch through the framework context;
+- cancellation tied to the Lambda invocation's remaining time;
+- asynchronous disposal of scoped services.
+
+This is intentionally similar to the useful infrastructure that v5 could provide at comparatively low invocation cost, while retaining the v6 handler and context contracts.
+
+## What minimal hosting omits
+
+The minimal host does not execute the normal host's internal invocation telemetry or richer processing pipeline. In particular it does not provide:
+
+- Kralizek.Lambda.Template `ActivitySource` activities or `Meter` instruments;
+- record processing or per-record result semantics;
+- source-specific envelope orchestration;
+- partial-batch response translation;
+- nested record-context propagation;
+- source-specific record processors.
+
+Those capabilities remain part of the normal/source-specific v6 hosts.
+
+There are intentionally no `MinimalSqsFunction`, `MinimalSnsFunction`, `MinimalS3Function`, or equivalent source-specific Minimal types in v6.0.
+
+## OpenTelemetry
+
+`--minimal --otel` still uses the standard AWS Lambda OpenTelemetry wrapper around `FunctionHandlerAsync`, so the Lambda invocation is traced.
+
+The generated Minimal function does **not** subscribe to `LambdaTelemetry.ActivitySourceName`, create a KLT `MeterProvider`, or flush KLT meters because Minimal does not emit those inner framework signals. Application code and dependencies can still register and emit their own OpenTelemetry activities and metrics normally.
+
+Conceptually:
+
+```text
+Minimal + OpenTelemetry
+└── Lambda invocation span
+    └── application/dependency instrumentation, if configured
+
+Normal + OpenTelemetry
+└── Lambda invocation span
+    ├── KLT internal activities and metrics
+    └── application/dependency instrumentation
+```
+
+## Native AOT
+
+Minimal hosting is compatible with the generic Request/Event templates' `--aot` option. AOT still controls executable hosting and source-generated Lambda serialization; Minimal controls the framework hosting path used once the invocation reaches the function.
+
+```bash
+dotnet new lambda-template-request --minimal --aot
+```
+
+## Templates
+
+The generic Request and Event templates expose `--minimal`:
+
+```bash
+dotnet new lambda-template-request --minimal
+dotnet new lambda-template-event --minimal
+dotnet new lambda-template-event --minimal --otel
+dotnet new lambda-template-request --minimal --aot
+```
+
+For these templates, switching between the normal and Minimal host changes `Function.cs`; handler and application files are unchanged.
+
+`--raw` remains an independent payload/record-shape option on the source-specific record templates that support it. V6.0 intentionally does not add Minimal source-specific record hosts, so no generated source-specific template currently combines `--minimal` and `--raw`.
+
+## Choosing the host
+
+Prefer the normal host when the function uses source-specific processing semantics, record processing, framework telemetry, or other behavior provided by the full v6 pipeline.
+
+Prefer Minimal for source-neutral request/event functions where the application wants the v6 handler/context/DI model but does not need that additional orchestration and wants invocation overhead closer to the raw Lambda runtime.
+
+The normal host remains the default. Minimal is an explicit performance-oriented trade-off, not a compatibility mode.

--- a/docs/Programming-Model.md
+++ b/docs/Programming-Model.md
@@ -8,10 +8,12 @@ The runtime is built around three semantic function roots rather than AWS-servic
 
 Application behavior lives in handler classes resolved through dependency injection. Function classes stay small and primarily select the programming model and provide configuration hooks.
 
-Source-specific packages layer AWS behavior on top of these roots. They own envelope mapping, source metadata, payload decoding where applicable, record-result semantics, and AWS-specific retry/failure responses.
+For source-neutral request and event functions, v6 also provides `MinimalEventFunction` and `MinimalRequestFunction`. These are alternative hosts for the **same handler contracts**, not additional programming models. They retain configuration, logging, dependency injection, invocation scopes, contexts, and cancellation while omitting the normal host's internal telemetry and richer processing path. See [Minimal Hosting](Minimal-Hosting.md).
+
+Source-specific packages layer AWS behavior on top of the normal roots. They own envelope mapping, source metadata, payload decoding where applicable, record-result semantics, and AWS-specific retry/failure responses.
 
 Record processing has one additional reusable primitive: `IRecordProcessor<TRecord, TRecordResult, TContext>`. A record processor executes exactly one record using the same per-record dependency-injection lifetime semantics used by `RecordFunction`: it creates an independent record scope, resolves the configured record handler, invokes it, and disposes the scope.
 
 Normal applications do not need to use a record processor directly. It exists for advanced composition scenarios where one delivered record contains another record-oriented envelope and the inner records should retain the framework's normal scope semantics. It does not own envelope iteration, parallelism, retry/checkpoint behavior, or the final Lambda response; those remain responsibilities of the source-specific function pipeline.
 
-Continue with [Event Functions](Event-Functions.md), [Request Functions](Request-Functions.md), or [Record Functions](Record-Functions.md).
+Continue with [Event Functions](Event-Functions.md), [Request Functions](Request-Functions.md), [Record Functions](Record-Functions.md), or [Minimal Hosting](Minimal-Hosting.md).

--- a/docs/Project-Templates.md
+++ b/docs/Project-Templates.md
@@ -19,6 +19,15 @@ dotnet new list lambda-template
 
 All project templates accept `--profile`, `--region`, and `--role` to populate the generated `aws-lambda-tools-defaults.json` file.
 
+The generic Request and Event templates accept `--minimal` to use the lean host while keeping the same handler contract and application files:
+
+```bash
+dotnet new lambda-template-request --minimal
+dotnet new lambda-template-event --minimal
+```
+
+Minimal hosting retains configuration, logging, dependency injection, one invocation scope, the standard function context, cancellation, and asynchronous scope disposal. It deliberately omits the normal host's internal telemetry and richer processing pipeline. See [Minimal Hosting](Minimal-Hosting.md) for the capability boundary and guidance on choosing a host.
+
 All project templates also accept `--otel` to generate the function with OpenTelemetry enabled:
 
 ```bash
@@ -26,7 +35,9 @@ dotnet new lambda-template-request --otel
 dotnet new lambda-template-sqs --otel
 ```
 
-OpenTelemetry is a template-time opt-in. Without `--otel`, the generated project contains no OpenTelemetry code, package references, build properties, or helper files. With `--otel`, the template adds the standard AWS Lambda OpenTelemetry instrumentation, subscribes to the framework activity source and meter, and exports through OTLP. See [OpenTelemetry](OpenTelemetry.md) for the telemetry model, X-Ray context behavior, and exporter customization.
+OpenTelemetry is a template-time opt-in. Without `--otel`, the generated project contains no OpenTelemetry code, package references, build properties, or helper files. With `--otel`, the template adds the standard AWS Lambda OpenTelemetry instrumentation and exports through OTLP.
+
+For the normal host, generated OpenTelemetry code also subscribes to the framework activity source and meter. With `--minimal --otel`, the AWS Lambda wrapper still traces the invocation, but the generated function does not subscribe to KLT's internal `ActivitySource` or `Meter` because Minimal does not emit those signals. Application code remains free to configure its own instrumentation. See [OpenTelemetry](OpenTelemetry.md) for the telemetry model, X-Ray context behavior, and exporter customization.
 
 All project templates accept `--aot` to generate a Native AOT executable using `LambdaBootstrapBuilder` and source-generated System.Text.Json metadata:
 
@@ -35,7 +46,7 @@ dotnet new lambda-template-request --aot
 dotnet new lambda-template-sqs --aot
 ```
 
-AOT changes hosting and serialization, not the framework programming model. A normal generated project is a managed Lambda library with an `Assembly::Type::FunctionHandlerAsync` handler and a `LambdaSerializer` assembly attribute. An AOT project enables `PublishAot`, adds `Program.cs` with `LambdaBootstrapBuilder` and `SourceGeneratorLambdaJsonSerializer`, uses the executable assembly as the Lambda handler, and has no `LambdaSerializer` assembly attribute. Both target the managed .NET 10 Lambda runtime. See [Native AOT](Native-AOT.md) for serializer metadata ownership, nested payload decoding, and deployment details.
+AOT changes executable hosting and serialization, not the framework handler programming model. A normal generated project is a managed Lambda library with an `Assembly::Type::FunctionHandlerAsync` handler and a `LambdaSerializer` assembly attribute. An AOT project enables `PublishAot`, adds `Program.cs` with `LambdaBootstrapBuilder` and `SourceGeneratorLambdaJsonSerializer`, uses the executable assembly as the Lambda handler, and has no `LambdaSerializer` assembly attribute. Both target the managed .NET 10 Lambda runtime. See [Native AOT](Native-AOT.md) for serializer metadata ownership, nested payload decoding, and deployment details.
 
 The SQS, SNS, and Kinesis Streams templates generate decoded payload handlers by default. Pass `--raw` when application code should receive the original AWS record instead:
 
@@ -47,21 +58,25 @@ dotnet new lambda-template-kinesis-stream --raw
 
 Raw mode changes only the generated handler shape. It uses the source-specific raw record handler contract and omits typed nested-payload metadata because no application payload is decoded.
 
-The three opt-in dimensions are orthogonal:
+The opt-in dimensions describe independent concerns where the selected template supports them:
 
 ```text
---raw  = handler/payload shape
---aot  = hosting + serialization
---otel = invocation instrumentation
+--minimal = lean request/event hosting
+--raw     = record/payload shape
+--aot     = executable hosting + serialization
+--otel    = invocation instrumentation
 ```
 
-They can be composed without selecting a separate template family:
+They can be composed without selecting a separate template family when those options apply to the same template:
 
 ```bash
+dotnet new lambda-template-event --minimal --otel
+dotnet new lambda-template-request --minimal --aot
 dotnet new lambda-template-sns --aot --raw
-dotnet new lambda-template-event --aot --otel
 dotnet new lambda-template-kinesis-stream --aot --otel --raw
 ```
+
+V6.0 exposes `--minimal` only on the source-neutral Request and Event templates. Source-specific Minimal hosts, including Minimal record functions, are intentionally outside the initial scope; consequently no current generated source-specific template combines `--minimal` and `--raw`.
 
 The Cognito pre-token-generation template also accepts `--version v1|v2`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ AWS Lambda Sharp Template provides .NET 10 runtime libraries and `dotnet new` te
 
 - New to the library? Read [Getting Started](Getting-Started.md).
 - Unsure which base type to use? Read [Choosing a Function Model](Choosing-a-Function-Model.md).
+- Want the same request/event handlers with less hosting overhead? Read [Minimal Hosting](Minimal-Hosting.md).
 - Migrating an existing application? Read [Migrating from v5 to v6](Migrating-from-v5-to-v6.md).
 - Composing nested record envelopes? Read [Record Processing](Record-Processing.md).
 - Adding traces and metrics? Read [OpenTelemetry](OpenTelemetry.md).
@@ -31,6 +32,8 @@ AWS Lambda Sharp Template provides .NET 10 runtime libraries and `dotnet new` te
 
 Source-specific packages specialize these roots while preserving a common model for dependency injection, configuration, logging, cancellation, contexts, and handler dispatch. `IRecordProcessor<TRecord, TRecordResult, TContext>` exposes the single-record execution primitive for advanced nested-record composition while source-specific functions retain ownership of envelope scheduling and AWS failure semantics.
 
+`MinimalEventFunction` and `MinimalRequestFunction` are alternative hosts for the existing Event/Request handler contracts. They are not additional programming models: they preserve the same handler/context/DI surface while deliberately omitting the normal host's internal telemetry and richer processing path.
+
 ## Install the templates
 
 ```bash
@@ -43,4 +46,4 @@ Then list the available templates:
 dotnet new list lambda-template
 ```
 
-Generated projects target .NET 10 and use the standard AWS Lambda .NET tooling. The template choices are independent where supported: `--raw` selects the record/payload shape, `--aot` selects executable hosting and source-generated Lambda serialization, and `--otel` adds Lambda invocation instrumentation.
+Generated projects target .NET 10 and use the standard AWS Lambda .NET tooling. Template choices are independent where supported: `--minimal` selects lean hosting for generic Request/Event templates, `--raw` selects the record/payload shape on supported record templates, `--aot` selects executable hosting and source-generated Lambda serialization, and `--otel` adds Lambda invocation instrumentation.

--- a/samples/EventFunction/README.md
+++ b/samples/EventFunction/README.md
@@ -27,7 +27,7 @@ There is deliberately no Terraform example here: `EventFunction<TInput, THandler
 
 ## Look at
 
-- `Function` for the minimal event-function declaration.
+- `Function` for the event-function declaration.
 - `StringEventHandler` for constructor injection and access to invocation metadata through `EventContext`.
 
-For request/response invocations, compare this sample with [RequestFunction](../RequestFunction/). For an AWS-specific envelope with a typed payload, see [EventBridgeFunction](../EventBridgeFunction/).
+For the same handler model on the lean host, compare [MinimalEventFunction](../MinimalEventFunction/). For request/response invocations, compare [RequestFunction](../RequestFunction/). For an AWS-specific envelope with a typed payload, see [EventBridgeFunction](../EventBridgeFunction/).

--- a/samples/MinimalEventFunction/Function.cs
+++ b/samples/MinimalEventFunction/Function.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Logging;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
-namespace EventFunction;
+namespace MinimalEventFunction;
 
-public class Function : EventFunction<string, StringEventHandler>;
+public class Function : MinimalEventFunction<string, StringEventHandler>;
 
 public class StringEventHandler : IEventHandler<string>
 {

--- a/samples/MinimalEventFunction/Function.cs
+++ b/samples/MinimalEventFunction/Function.cs
@@ -24,7 +24,7 @@ public class StringEventHandler : IEventHandler<string>
 
     public ValueTask HandleAsync(string input, EventContext context, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Input {Input} for request {AwsRequestId}", input, context.AwsRequestId);
+        _logger.LogInformation("Input {Input} for invocation {AwsRequestId}", input, context.AwsRequestId);
         return ValueTask.CompletedTask;
     }
 }

--- a/samples/MinimalEventFunction/MinimalEventFunction.csproj
+++ b/samples/MinimalEventFunction/MinimalEventFunction.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MinimalEventFunction/README.md
+++ b/samples/MinimalEventFunction/README.md
@@ -1,0 +1,20 @@
+# MinimalEventFunction sample
+
+Use this sample when a Lambda consumes a source-neutral event and you want the v6 handler, context, dependency-injection, logging, and cancellation model without the full invocation processing pipeline.
+
+```text
+JSON input
+  → Lambda serializer
+  → MinimalEventFunction<string, StringEventHandler>
+  → StringEventHandler
+```
+
+The application handler is the same shape used by the normal `EventFunction` host: `IEventHandler<string>` receives an `EventContext` and `CancellationToken`, and constructor injection works normally.
+
+A direct test invocation can be:
+
+```json
+"hello from Lambda"
+```
+
+Compare this sample with [EventFunction](../EventFunction/) to see the hosting difference. The handler model stays the same; only the function host changes.

--- a/samples/MinimalEventFunction/aws-lambda-tools-defaults.json
+++ b/samples/MinimalEventFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "test-lambda-template-minimal-event",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "MinimalEventFunction::MinimalEventFunction.Function::FunctionHandlerAsync"
+}

--- a/samples/MinimalRequestFunction/Function.cs
+++ b/samples/MinimalRequestFunction/Function.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Logging;
 
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
 
-namespace RequestFunction;
+namespace MinimalRequestFunction;
 
-public class Function : RequestFunction<string, string, UpperCaseHandler>;
+public class Function : MinimalRequestFunction<string, string, UpperCaseHandler>;
 
 public class UpperCaseHandler : IRequestHandler<string, string>
 {

--- a/samples/MinimalRequestFunction/MinimalRequestFunction.csproj
+++ b/samples/MinimalRequestFunction/MinimalRequestFunction.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kralizek.Lambda.Template\Kralizek.Lambda.Template.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MinimalRequestFunction/README.md
+++ b/samples/MinimalRequestFunction/README.md
@@ -1,0 +1,27 @@
+# MinimalRequestFunction sample
+
+Use this sample when a Lambda has a source-neutral request/response shape and you want the v6 handler, context, dependency-injection, logging, and cancellation model without the full invocation processing pipeline.
+
+```text
+JSON request
+  → Lambda serializer
+  → MinimalRequestFunction<string, string, UpperCaseHandler>
+  → UpperCaseHandler
+  → JSON response
+```
+
+The application handler is the same shape used by the normal `RequestFunction` host: `IRequestHandler<string, string>` receives a `RequestContext` and `CancellationToken`, and constructor injection works normally.
+
+A direct invocation can use:
+
+```json
+"hello from Lambda"
+```
+
+and returns:
+
+```json
+"HELLO FROM LAMBDA"
+```
+
+Compare this sample with [RequestFunction](../RequestFunction/) to see the hosting difference. The handler model stays the same; only the function host changes.

--- a/samples/MinimalRequestFunction/aws-lambda-tools-defaults.json
+++ b/samples/MinimalRequestFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,20 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET CLI.",
+    "To learn more about the Lambda commands with the .NET CLI execute the following command at the command line in the project root directory.",
+
+    "dotnet lambda help",
+
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+
+  "profile": "",
+  "region": "eu-west-1",
+  "configuration": "Release",
+  "framework": "net10.0",
+  "function-runtime": "dotnet10",
+  "function-name": "test-lambda-template-minimal-request",
+  "function-memory-size": 256,
+  "function-timeout": 30,
+  "function-handler": "MinimalRequestFunction::MinimalRequestFunction.Function::FunctionHandlerAsync"
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,9 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | If you want to demonstrate... | Start here | What it shows |
 | --- | --- | --- |
 | A Lambda that consumes an event and returns no application response | [EventFunction](EventFunction/) | `EventFunction<TInput, THandler>`, handler DI, logging, and `EventContext` |
+| The same source-neutral event model on the lean host | [MinimalEventFunction](MinimalEventFunction/) | `MinimalEventFunction<TInput, THandler>` with the same handler/context/DI contract and less invocation machinery |
 | A Lambda with a typed request and response | [RequestFunction](RequestFunction/) | `RequestFunction<TInput, TOutput, THandler>` and `RequestContext` |
+| The same source-neutral request model on the lean host | [MinimalRequestFunction](MinimalRequestFunction/) | `MinimalRequestFunction<TInput, TOutput, THandler>` with the same handler/context/DI contract and less invocation machinery |
 | Native AOT hosting for a typed SQS function | [NativeAotSqsFunction](NativeAotSqsFunction/) | executable Lambda bootstrap, source-generated boundary metadata, and an AOT-safe nested JSON decoder |
 | Native AOT for S3 events delivered through an SNS envelope and SQS | [NativeAotSqsSnsS3Function](NativeAotSqsSnsS3Function/) | typed SNS-envelope decoding plus AOT-safe nested S3 event decoding |
 | OpenTelemetry instrumentation for a request/response Lambda | [OpenTelemetryRequestFunction](OpenTelemetryRequestFunction/) | wrapping the inherited request handler with `AWSLambdaWrapper.TraceAsync` and exporting the invocation span |
@@ -27,6 +29,10 @@ Each sample README shows the expected Lambda input shape and how that input maps
 | A Cognito trigger that mutates and returns the trigger event | [CognitoPreSignUpFunction](CognitoPreSignUpFunction/) | a concrete Cognito specialization using the pre-sign-up contract |
 
 ## Useful comparisons
+
+### Full vs minimal hosting
+
+Compare [EventFunction](EventFunction/) with [MinimalEventFunction](MinimalEventFunction/), or [RequestFunction](RequestFunction/) with [MinimalRequestFunction](MinimalRequestFunction/). Each pair uses the same application handler shape, context model, dependency injection, logging, and cancellation. The difference is the host: the Minimal samples omit the richer invocation processing and internal KLT telemetry path.
 
 ### Generic event vs request/response
 

--- a/samples/RequestFunction/README.md
+++ b/samples/RequestFunction/README.md
@@ -35,4 +35,4 @@ There is deliberately no Terraform example here: `RequestFunction<TInput, TOutpu
 - `Function` for the input, output, and handler types declared in one place.
 - `UpperCaseHandler` for constructor injection, `RequestContext`, and returning a response asynchronously.
 
-If the invocation only needs to consume an event, compare this sample with [EventFunction](../EventFunction/). For a concrete AWS request/response trigger, see [CognitoPreSignUpFunction](../CognitoPreSignUpFunction/).
+For the same handler model on the lean host, compare [MinimalRequestFunction](../MinimalRequestFunction/). If the invocation only needs to consume an event, compare this sample with [EventFunction](../EventFunction/). For a concrete AWS request/response trigger, see [CognitoPreSignUpFunction](../CognitoPreSignUpFunction/).

--- a/src/Kralizek.Lambda.Template/LambdaFunction.cs
+++ b/src/Kralizek.Lambda.Template/LambdaFunction.cs
@@ -18,39 +18,14 @@ public abstract class LambdaFunction
 #pragma warning disable S1699 // Configuration hooks intentionally execute during base construction. Overrides must not depend on derived-constructor state.
     protected LambdaFunction()
     {
-        var configurationBuilder = new ConfigurationBuilder();
+        var host = LambdaHostBuilder.Build(
+            ConfigureConfiguration,
+            ConfigureLogging,
+            RegisterFrameworkServices,
+            ConfigureServices);
 
-        ConfigureConfiguration(configurationBuilder);
-
-        Configuration = configurationBuilder.Build();
-
-        var executionEnvironment = new LambdaExecutionEnvironment
-        {
-            EnvironmentName = Configuration["Environment"] ?? LambdaExecutionEnvironment.DevelopmentEnvironmentName,
-            IsLambda = Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_DIR") != null
-        };
-
-        var services = new ServiceCollection();
-
-        services.AddSingleton<IExecutionEnvironment>(executionEnvironment);
-        services.AddSingleton<IConfiguration>(Configuration);
-        services.AddSingleton(Configuration);
-        services.AddLogging(logging =>
-        {
-            logging.AddLambdaLogger(new LambdaLoggerOptions
-            {
-                IncludeCategory = true,
-                IncludeLogLevel = true,
-                IncludeNewline = true
-            });
-
-            ConfigureLogging(logging);
-        });
-
-        RegisterFrameworkServices(services);
-        ConfigureServices(services, Configuration);
-
-        ServiceProvider = services.BuildServiceProvider();
+        Configuration = host.Configuration;
+        ServiceProvider = host.ServiceProvider;
         Logger = ServiceProvider.GetRequiredService<ILogger<LambdaFunction>>();
     }
 #pragma warning restore S1699
@@ -148,22 +123,6 @@ public abstract class LambdaFunction
     /// <summary>
     /// Creates a <see cref="CancellationTokenSource"/> that is cancelled when the Lambda invocation runs out of time.
     /// </summary>
-    protected static CancellationTokenSource CreateCancellationTokenSource(ILambdaContext context)
-    {
-        ArgumentNullException.ThrowIfNull(context);
-
-        var cancellationTokenSource = new CancellationTokenSource();
-        var remaining = context.RemainingTime;
-
-        if (remaining <= TimeSpan.Zero)
-        {
-            cancellationTokenSource.Cancel();
-        }
-        else if (remaining < TimeSpan.FromMilliseconds(int.MaxValue))
-        {
-            cancellationTokenSource.CancelAfter(remaining);
-        }
-
-        return cancellationTokenSource;
-    }
+    protected static CancellationTokenSource CreateCancellationTokenSource(ILambdaContext context) =>
+        LambdaInvocationLifetime.CreateCancellationTokenSource(context);
 }

--- a/src/Kralizek.Lambda.Template/LambdaHostBuilder.cs
+++ b/src/Kralizek.Lambda.Template/LambdaHostBuilder.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+
+using Amazon.Lambda.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Kralizek.Lambda;
+
+internal sealed class LambdaHost
+{
+    public LambdaHost(IConfigurationRoot configuration, IServiceProvider serviceProvider)
+    {
+        Configuration = configuration;
+        ServiceProvider = serviceProvider;
+    }
+
+    public IConfigurationRoot Configuration { get; }
+
+    public IServiceProvider ServiceProvider { get; }
+}
+
+internal static class LambdaHostBuilder
+{
+    public static LambdaHost Build(
+        Action<IConfigurationBuilder> configureConfiguration,
+        Action<ILoggingBuilder> configureLogging,
+        Action<IServiceCollection> registerFrameworkServices,
+        Action<IServiceCollection, IConfiguration> configureServices)
+    {
+        var configurationBuilder = new ConfigurationBuilder();
+        configureConfiguration(configurationBuilder);
+
+        var configuration = configurationBuilder.Build();
+        var executionEnvironment = new LambdaExecutionEnvironment
+        {
+            EnvironmentName = configuration["Environment"] ?? LambdaExecutionEnvironment.DevelopmentEnvironmentName,
+            IsLambda = Environment.GetEnvironmentVariable("LAMBDA_RUNTIME_DIR") != null
+        };
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IExecutionEnvironment>(executionEnvironment);
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton(configuration);
+        services.AddLogging(logging =>
+        {
+            logging.AddLambdaLogger(new LambdaLoggerOptions
+            {
+                IncludeCategory = true,
+                IncludeLogLevel = true,
+                IncludeNewline = true
+            });
+
+            configureLogging(logging);
+        });
+
+        registerFrameworkServices(services);
+        configureServices(services, configuration);
+
+        return new LambdaHost(configuration, services.BuildServiceProvider());
+    }
+}
+
+internal static class LambdaInvocationLifetime
+{
+    public static CancellationTokenSource CreateCancellationTokenSource(ILambdaContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var cancellationTokenSource = new CancellationTokenSource();
+        var remaining = context.RemainingTime;
+
+        if (remaining <= TimeSpan.Zero)
+        {
+            cancellationTokenSource.Cancel();
+        }
+        else if (remaining < TimeSpan.FromMilliseconds(int.MaxValue))
+        {
+            cancellationTokenSource.CancelAfter(remaining);
+        }
+
+        return cancellationTokenSource;
+    }
+}

--- a/src/Kralizek.Lambda.Template/MinimalEventFunction.cs
+++ b/src/Kralizek.Lambda.Template/MinimalEventFunction.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Kralizek.Lambda;
+
+/// <summary>
+/// A minimal host for handlers that process a single event and produce no meaningful response.
+/// </summary>
+/// <typeparam name="TInput">The type of the incoming event.</typeparam>
+/// <typeparam name="TContext">The context type passed to the handler.</typeparam>
+/// <typeparam name="THandler">The concrete handler type that processes the event.</typeparam>
+#pragma warning disable S2436 // The generic roles are intentional and make the event contract explicit.
+public abstract class MinimalEventFunction<TInput, TContext, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler> : MinimalLambdaFunction
+#pragma warning restore S2436
+    where TContext : EventContext
+    where THandler : class, IEventHandler<TInput, TContext>
+{
+    protected sealed override void RegisterFrameworkServices(IServiceCollection services)
+    {
+        base.RegisterFrameworkServices(services);
+        services.TryAddScoped<THandler>();
+        ConfigureFrameworkServices(services);
+    }
+
+    /// <summary>
+    /// Registers replaceable services for this event-function specialization.
+    /// </summary>
+    protected virtual void ConfigureFrameworkServices(IServiceCollection services)
+    {
+    }
+
+    protected abstract TContext CreateContext(TInput input, ILambdaContext context);
+
+    public virtual async Task FunctionHandlerAsync(TInput input, ILambdaContext context)
+    {
+        using var cts = CreateCancellationTokenSource(context);
+        cts.Token.ThrowIfCancellationRequested();
+
+        var eventContext = CreateContext(input, context);
+
+        await using var invocationScope = ServiceProvider.CreateAsyncScope();
+        var handler = invocationScope.ServiceProvider.GetRequiredService<THandler>();
+
+        await handler.HandleAsync(input, eventContext, cts.Token).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// A minimal event-function host using the standard <see cref="EventContext"/>.
+/// </summary>
+public abstract class MinimalEventFunction<TInput, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler> : MinimalEventFunction<TInput, EventContext, THandler>
+    where THandler : class, IEventHandler<TInput, EventContext>
+{
+    protected override EventContext CreateContext(TInput input, ILambdaContext context) =>
+        FunctionContextFactory.CreateEventContext(context);
+}

--- a/src/Kralizek.Lambda.Template/MinimalLambdaFunction.cs
+++ b/src/Kralizek.Lambda.Template/MinimalLambdaFunction.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Threading;
+
+using Amazon.Lambda.Core;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Kralizek.Lambda;
+
+/// <summary>
+/// A lean hosting root for request and event functions that preserves configuration,
+/// logging, dependency injection, context, and cancellation without the full processing pipeline.
+/// </summary>
+public abstract class MinimalLambdaFunction
+{
+#pragma warning disable S1699 // Configuration hooks intentionally execute during base construction. Overrides must not depend on derived-constructor state.
+    protected MinimalLambdaFunction()
+    {
+        var host = LambdaHostBuilder.Build(
+            ConfigureConfiguration,
+            ConfigureLogging,
+            RegisterFrameworkServices,
+            ConfigureServices);
+
+        Configuration = host.Configuration;
+        ServiceProvider = host.ServiceProvider;
+        Logger = ServiceProvider.GetRequiredService<ILogger<MinimalLambdaFunction>>();
+    }
+#pragma warning restore S1699
+
+    /// <summary>
+    /// Override to add configuration sources used by the function.
+    /// </summary>
+    protected virtual void ConfigureConfiguration(IConfigurationBuilder configuration) { }
+
+    /// <summary>
+    /// Registers services required by the minimal function specialization before application services are configured.
+    /// </summary>
+    protected virtual void RegisterFrameworkServices(IServiceCollection services) { }
+
+    /// <summary>
+    /// Override to configure additional logging providers and options.
+    /// </summary>
+    protected virtual void ConfigureLogging(ILoggingBuilder logging) { }
+
+    /// <summary>
+    /// Override to register application services.
+    /// </summary>
+    protected virtual void ConfigureServices(IServiceCollection services, IConfiguration configuration) { }
+
+    /// <summary>
+    /// The configuration built during function initialization.
+    /// </summary>
+    protected IConfigurationRoot Configuration { get; }
+
+    /// <summary>
+    /// The root service provider built during function initialization.
+    /// </summary>
+    protected IServiceProvider ServiceProvider { get; }
+
+    /// <summary>
+    /// The function-level logger.
+    /// </summary>
+    protected ILogger Logger { get; }
+
+    /// <summary>
+    /// Creates a cancellation token source that is cancelled when the Lambda invocation runs out of time.
+    /// </summary>
+    protected static CancellationTokenSource CreateCancellationTokenSource(ILambdaContext context) =>
+        LambdaInvocationLifetime.CreateCancellationTokenSource(context);
+}

--- a/src/Kralizek.Lambda.Template/MinimalRequestFunction.cs
+++ b/src/Kralizek.Lambda.Template/MinimalRequestFunction.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Kralizek.Lambda;
+
+/// <summary>
+/// A minimal host for handlers that process a single request and return a meaningful response.
+/// </summary>
+/// <typeparam name="TInput">The type of the incoming request.</typeparam>
+/// <typeparam name="TOutput">The type of the response.</typeparam>
+/// <typeparam name="TContext">The context type passed to the handler.</typeparam>
+/// <typeparam name="THandler">The concrete handler type that processes the request.</typeparam>
+#pragma warning disable S2436 // The generic roles are intentional and make the request contract explicit.
+public abstract class MinimalRequestFunction<TInput, TOutput, TContext, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler> : MinimalLambdaFunction
+#pragma warning restore S2436
+    where TContext : RequestContext
+    where THandler : class, IRequestHandler<TInput, TOutput, TContext>
+{
+    protected sealed override void RegisterFrameworkServices(IServiceCollection services)
+    {
+        base.RegisterFrameworkServices(services);
+        services.TryAddScoped<THandler>();
+        ConfigureFrameworkServices(services);
+    }
+
+    /// <summary>
+    /// Registers replaceable services for this request-function specialization.
+    /// </summary>
+    protected virtual void ConfigureFrameworkServices(IServiceCollection services)
+    {
+    }
+
+    protected abstract TContext CreateContext(TInput input, ILambdaContext context);
+
+    public virtual async Task<TOutput> FunctionHandlerAsync(TInput input, ILambdaContext context)
+    {
+        using var cts = CreateCancellationTokenSource(context);
+        cts.Token.ThrowIfCancellationRequested();
+
+        var requestContext = CreateContext(input, context);
+
+        await using var invocationScope = ServiceProvider.CreateAsyncScope();
+        var handler = invocationScope.ServiceProvider.GetRequiredService<THandler>();
+
+        return await handler.HandleAsync(input, requestContext, cts.Token).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// A minimal request-function host using the standard <see cref="RequestContext"/>.
+/// </summary>
+#pragma warning disable S2436 // The three public roles intentionally hide the standard context type.
+public abstract class MinimalRequestFunction<TInput, TOutput, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] THandler> : MinimalRequestFunction<TInput, TOutput, RequestContext, THandler>
+#pragma warning restore S2436
+    where THandler : class, IRequestHandler<TInput, TOutput, RequestContext>
+{
+    protected override RequestContext CreateContext(TInput input, ILambdaContext context) =>
+        FunctionContextFactory.CreateRequestContext(context);
+}

--- a/src/Kralizek.Lambda.Template/README.md
+++ b/src/Kralizek.Lambda.Template/README.md
@@ -6,6 +6,14 @@ Core runtime for the source-neutral Event, Request, and Record programming model
 public sealed class Function : EventFunction<MyEvent, MyEventHandler>;
 ```
 
+Source-neutral Event and Request handlers can also use the Minimal host when they need the same v6 handler/context/DI model without the full invocation processing path:
+
+```csharp
+public sealed class Function : MinimalEventFunction<MyEvent, MyEventHandler>;
+```
+
+Minimal hosting retains configuration, logging, function-local dependency injection, one invocation scope, context, cancellation, and async scope disposal. See [Minimal Hosting](https://github.com/Kralizek/AWSLambdaSharpTemplate/blob/HEAD/docs/Minimal-Hosting.md) for the capability boundary and OpenTelemetry behavior.
+
 For usage, processing semantics, and examples, see [Programming Model](https://github.com/Kralizek/AWSLambdaSharpTemplate/blob/HEAD/docs/Programming-Model.md).
 
 The complete library documentation is available in the [`docs/` directory](https://github.com/Kralizek/AWSLambdaSharpTemplate/blob/HEAD/docs/README.md).

--- a/templates/content/EventFunction/.template.config/template.json
+++ b/templates/content/EventFunction/.template.config/template.json
@@ -12,6 +12,7 @@
     "profile": { "type": "parameter", "datatype": "string", "replaces": "DefaultProfile", "defaultValue": "" },
     "region": { "type": "parameter", "datatype": "string", "replaces": "DefaultRegion", "defaultValue": "" },
     "role": { "type": "parameter", "datatype": "string", "replaces": "DefaultRole", "defaultValue": "" },
+    "minimal": { "type": "parameter", "description": "Use the minimal hosting model while keeping the same event handler contract.", "datatype": "bool", "defaultValue": "false" },
     "otel": { "type": "parameter", "description": "Enable OpenTelemetry using the standard AWS Lambda instrumentation.", "datatype": "bool", "defaultValue": "false" },
     "aot": { "type": "parameter", "description": "Generate a Native AOT Lambda executable with source-generated JSON serialization.", "datatype": "bool", "defaultValue": "false" }
   },

--- a/templates/content/EventFunction/Function.cs
+++ b/templates/content/EventFunction/Function.cs
@@ -11,7 +11,9 @@ using Microsoft.Extensions.Logging;
 #if (otel)
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
+#if (!minimal)
 using OpenTelemetry.Metrics;
+#endif
 using OpenTelemetry.Trace;
 #endif
 
@@ -21,11 +23,17 @@ using OpenTelemetry.Trace;
 
 namespace LambdaFunctionProject;
 
+#if (minimal)
+public class Function : MinimalEventFunction<string, StringEventHandler>
+#else
 public class Function : EventFunction<string, StringEventHandler>
+#endif
 {
 #if (otel)
     private static readonly TracerProvider TracerProvider = ConfigureTracing();
+#if (!minimal)
     private static readonly MeterProvider MeterProvider = ConfigureMetrics();
+#endif
 #endif
 
     protected override void ConfigureConfiguration(IConfigurationBuilder configuration)
@@ -49,6 +57,13 @@ public class Function : EventFunction<string, StringEventHandler>
 #if (otel)
     public override async Task FunctionHandlerAsync(string input, ILambdaContext context)
     {
+#if (minimal)
+        await AWSLambdaWrapper.TraceAsync(
+            TracerProvider,
+            base.FunctionHandlerAsync,
+            input,
+            context).ConfigureAwait(false);
+#else
         try
         {
             await AWSLambdaWrapper.TraceAsync(
@@ -61,11 +76,17 @@ public class Function : EventFunction<string, StringEventHandler>
         {
             MeterProvider.ForceFlush();
         }
+#endif
     }
 
-    private static TracerProvider ConfigureTracing() =>
-        Sdk.CreateTracerProviderBuilder()
-            .AddSource(LambdaTelemetry.ActivitySourceName)
+    private static TracerProvider ConfigureTracing()
+    {
+        var builder = Sdk.CreateTracerProviderBuilder();
+#if (!minimal)
+        builder.AddSource(LambdaTelemetry.ActivitySourceName);
+#endif
+
+        return builder
             .AddAWSLambdaConfigurations(options =>
             {
                 // Uncomment when X-Ray is not used and its Lambda context prevents OpenTelemetry spans from being recorded.
@@ -73,11 +94,14 @@ public class Function : EventFunction<string, StringEventHandler>
             })
             .AddOtlpExporter()
             .Build();
+    }
 
+#if (!minimal)
     private static MeterProvider ConfigureMetrics() =>
         Sdk.CreateMeterProviderBuilder()
             .AddMeter(LambdaTelemetry.MeterName)
             .AddOtlpExporter()
             .Build();
+#endif
 #endif
 }

--- a/templates/content/RequestFunction/.template.config/template.json
+++ b/templates/content/RequestFunction/.template.config/template.json
@@ -12,6 +12,7 @@
     "profile": { "type": "parameter", "datatype": "string", "replaces": "DefaultProfile", "defaultValue": "" },
     "region": { "type": "parameter", "datatype": "string", "replaces": "DefaultRegion", "defaultValue": "" },
     "role": { "type": "parameter", "datatype": "string", "replaces": "DefaultRole", "defaultValue": "" },
+    "minimal": { "type": "parameter", "description": "Use the minimal hosting model while keeping the same request handler contract.", "datatype": "bool", "defaultValue": "false" },
     "otel": { "type": "parameter", "description": "Enable OpenTelemetry using the standard AWS Lambda instrumentation.", "datatype": "bool", "defaultValue": "false" },
     "aot": { "type": "parameter", "description": "Generate a Native AOT Lambda executable with source-generated JSON serialization.", "datatype": "bool", "defaultValue": "false" }
   },

--- a/templates/content/RequestFunction/Function.cs
+++ b/templates/content/RequestFunction/Function.cs
@@ -11,7 +11,9 @@ using Microsoft.Extensions.Logging;
 #if (otel)
 using OpenTelemetry;
 using OpenTelemetry.Instrumentation.AWSLambda;
+#if (!minimal)
 using OpenTelemetry.Metrics;
+#endif
 using OpenTelemetry.Trace;
 #endif
 
@@ -21,11 +23,17 @@ using OpenTelemetry.Trace;
 
 namespace LambdaFunctionProject;
 
+#if (minimal)
+public class Function : MinimalRequestFunction<string, string, ToUpperStringRequestHandler>
+#else
 public class Function : RequestFunction<string, string, ToUpperStringRequestHandler>
+#endif
 {
 #if (otel)
     private static readonly TracerProvider TracerProvider = ConfigureTracing();
+#if (!minimal)
     private static readonly MeterProvider MeterProvider = ConfigureMetrics();
+#endif
 #endif
 
     protected override void ConfigureConfiguration(IConfigurationBuilder configuration)
@@ -49,6 +57,13 @@ public class Function : RequestFunction<string, string, ToUpperStringRequestHand
 #if (otel)
     public override async Task<string> FunctionHandlerAsync(string input, ILambdaContext context)
     {
+#if (minimal)
+        return await AWSLambdaWrapper.TraceAsync(
+            TracerProvider,
+            base.FunctionHandlerAsync,
+            input,
+            context).ConfigureAwait(false);
+#else
         try
         {
             return await AWSLambdaWrapper.TraceAsync(
@@ -61,11 +76,17 @@ public class Function : RequestFunction<string, string, ToUpperStringRequestHand
         {
             MeterProvider.ForceFlush();
         }
+#endif
     }
 
-    private static TracerProvider ConfigureTracing() =>
-        Sdk.CreateTracerProviderBuilder()
-            .AddSource(LambdaTelemetry.ActivitySourceName)
+    private static TracerProvider ConfigureTracing()
+    {
+        var builder = Sdk.CreateTracerProviderBuilder();
+#if (!minimal)
+        builder.AddSource(LambdaTelemetry.ActivitySourceName);
+#endif
+
+        return builder
             .AddAWSLambdaConfigurations(options =>
             {
                 // Uncomment when X-Ray is not used and its Lambda context prevents OpenTelemetry spans from being recorded.
@@ -73,11 +94,14 @@ public class Function : RequestFunction<string, string, ToUpperStringRequestHand
             })
             .AddOtlpExporter()
             .Build();
+    }
 
+#if (!minimal)
     private static MeterProvider ConfigureMetrics() =>
         Sdk.CreateMeterProviderBuilder()
             .AddMeter(LambdaTelemetry.MeterName)
             .AddOtlpExporter()
             .Build();
+#endif
 #endif
 }

--- a/tests/Tests.Lambda.Template/MinimalFunctionTests.cs
+++ b/tests/Tests.Lambda.Template/MinimalFunctionTests.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.Lambda.Core;
+using Amazon.Lambda.TestUtilities;
+
+using Kralizek.Lambda;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using NUnit.Framework;
+
+namespace Tests.Lambda;
+
+[TestFixture]
+public class MinimalFunctionTests
+{
+    [SetUp]
+    public void SetUp()
+    {
+        TrackingEventHandler.Reset();
+        TrackingRequestHandler.Reset();
+        ScopedTrackingHandler.ScopeIds.Clear();
+        AsyncDisposableDependency.WasDisposed = false;
+    }
+
+    [Test]
+    public void MinimalEventFunction_preserves_configuration_service_and_logging_hooks()
+    {
+        var sut = new ConfiguredMinimalEventFunction();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sut.IsConfigureConfigurationInvoked, Is.True);
+            Assert.That(sut.IsConfigureServicesInvoked, Is.True);
+            Assert.That(sut.IsConfigureLoggingInvoked, Is.True);
+        });
+    }
+
+    [Test]
+    public async Task MinimalEventFunction_invokes_existing_handler_contract_with_standard_context()
+    {
+        var sut = new TrackingMinimalEventFunction();
+        var lambdaContext = TestLambdaContexts.Create();
+        lambdaContext.AwsRequestId = "minimal-event";
+
+        await sut.FunctionHandlerAsync("expected", lambdaContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(TrackingEventHandler.Input, Is.EqualTo("expected"));
+            Assert.That(TrackingEventHandler.Context?.AwsRequestId, Is.EqualTo("minimal-event"));
+            Assert.That(TrackingEventHandler.Context?.GetLambdaContext(), Is.SameAs(lambdaContext));
+        });
+    }
+
+    [Test]
+    public async Task MinimalRequestFunction_invokes_existing_handler_contract_with_standard_context()
+    {
+        var sut = new TrackingMinimalRequestFunction();
+        var lambdaContext = TestLambdaContexts.Create();
+        lambdaContext.AwsRequestId = "minimal-request";
+
+        var result = await sut.FunctionHandlerAsync("hello", lambdaContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.EqualTo("HELLO"));
+            Assert.That(TrackingRequestHandler.Context?.AwsRequestId, Is.EqualTo("minimal-request"));
+            Assert.That(TrackingRequestHandler.Context?.GetLambdaContext(), Is.SameAs(lambdaContext));
+        });
+    }
+
+    [Test]
+    public void MinimalEventFunction_cancels_before_handler_when_no_execution_time_remains()
+    {
+        var sut = new TrackingMinimalEventFunction();
+        var lambdaContext = new TestLambdaContext { RemainingTime = TimeSpan.Zero };
+
+        Assert.ThrowsAsync<OperationCanceledException>(() => sut.FunctionHandlerAsync("hello", lambdaContext));
+        Assert.That(TrackingEventHandler.Input, Is.Null);
+    }
+
+    [Test]
+    public async Task MinimalEventFunction_creates_an_independent_scope_per_invocation()
+    {
+        var sut = new ScopedMinimalEventFunction();
+        var context = TestLambdaContexts.Create();
+
+        await sut.FunctionHandlerAsync("first", context);
+        await sut.FunctionHandlerAsync("second", context);
+
+        Assert.That(ScopedTrackingHandler.ScopeIds, Has.Count.EqualTo(2));
+        Assert.That(ScopedTrackingHandler.ScopeIds[0], Is.Not.EqualTo(ScopedTrackingHandler.ScopeIds[1]));
+    }
+
+    [Test]
+    public async Task MinimalEventFunction_async_disposes_scoped_dependencies_after_handler_completion()
+    {
+        var sut = new AsyncDisposableMinimalEventFunction();
+
+        await sut.FunctionHandlerAsync("trigger", TestLambdaContexts.Create());
+
+        Assert.That(AsyncDisposableDependency.WasDisposed, Is.True);
+    }
+
+    [Test]
+    public async Task MinimalEventFunction_passes_specialized_context_without_changing_handler_contract()
+    {
+        SpecializedMinimalEventHandler.ReceivedContext = null;
+        var sut = new SpecializedMinimalEventFunction();
+        var lambdaContext = TestLambdaContexts.Create();
+
+        await sut.FunctionHandlerAsync("expected", lambdaContext);
+
+        Assert.That(SpecializedMinimalEventHandler.ReceivedContext?.Input, Is.EqualTo("expected"));
+        Assert.That(SpecializedMinimalEventHandler.ReceivedContext?.GetLambdaContext(), Is.SameAs(lambdaContext));
+    }
+
+    public sealed class ConfiguredMinimalEventFunction : MinimalEventFunction<string, TrackingEventHandler>
+    {
+        protected override void ConfigureConfiguration(IConfigurationBuilder configuration) => IsConfigureConfigurationInvoked = true;
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) => IsConfigureServicesInvoked = true;
+        protected override void ConfigureLogging(ILoggingBuilder logging) => IsConfigureLoggingInvoked = true;
+
+        public bool IsConfigureConfigurationInvoked { get; private set; }
+        public bool IsConfigureServicesInvoked { get; private set; }
+        public bool IsConfigureLoggingInvoked { get; private set; }
+    }
+
+    public sealed class TrackingMinimalEventFunction : MinimalEventFunction<string, TrackingEventHandler> { }
+
+    public sealed class TrackingMinimalRequestFunction : MinimalRequestFunction<string, string, TrackingRequestHandler> { }
+
+    public sealed class ScopedMinimalEventFunction : MinimalEventFunction<string, ScopedTrackingHandler>
+    {
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
+            services.AddScoped<ScopedDependency>();
+    }
+
+    public sealed class AsyncDisposableMinimalEventFunction : MinimalEventFunction<string, AsyncDisposableHandler>
+    {
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
+            services.AddScoped<AsyncDisposableDependency>();
+    }
+
+    public sealed class SpecializedMinimalEventFunction : MinimalEventFunction<string, SpecializedEventContext, SpecializedMinimalEventHandler>
+    {
+        protected override SpecializedEventContext CreateContext(string input, ILambdaContext context) => new(context, input);
+    }
+
+    public sealed class SpecializedEventContext : EventContext
+    {
+        public SpecializedEventContext(ILambdaContext context, string input)
+            : base(FunctionContextFactory.CreateMetadata(context), FunctionContextFactory.CreateProperties(context))
+        {
+            Input = input;
+        }
+
+        public string Input { get; }
+    }
+
+    public sealed class TrackingEventHandler : IEventHandler<string>
+    {
+        public static string? Input { get; private set; }
+        public static EventContext? Context { get; private set; }
+
+        public static void Reset()
+        {
+            Input = null;
+            Context = null;
+        }
+
+        public ValueTask HandleAsync(string input, EventContext context, CancellationToken cancellationToken)
+        {
+            Input = input;
+            Context = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class TrackingRequestHandler : IRequestHandler<string, string>
+    {
+        public static RequestContext? Context { get; private set; }
+
+        public static void Reset() => Context = null;
+
+        public ValueTask<string> HandleAsync(string input, RequestContext context, CancellationToken cancellationToken)
+        {
+            Context = context;
+            return ValueTask.FromResult(input.ToUpperInvariant());
+        }
+    }
+
+    public sealed class ScopedDependency
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    public sealed class ScopedTrackingHandler : IEventHandler<string>
+    {
+        private readonly ScopedDependency _dependency;
+
+        public ScopedTrackingHandler(ScopedDependency dependency) => _dependency = dependency;
+
+        public static List<Guid> ScopeIds { get; } = [];
+
+        public ValueTask HandleAsync(string input, EventContext context, CancellationToken cancellationToken)
+        {
+            ScopeIds.Add(_dependency.Id);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class AsyncDisposableDependency : IAsyncDisposable
+    {
+        public static bool WasDisposed { get; set; }
+
+        public ValueTask DisposeAsync()
+        {
+            WasDisposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class AsyncDisposableHandler : IEventHandler<string>
+    {
+        private readonly AsyncDisposableDependency _dependency;
+
+        public AsyncDisposableHandler(AsyncDisposableDependency dependency) => _dependency = dependency;
+
+        public ValueTask HandleAsync(string input, EventContext context, CancellationToken cancellationToken)
+        {
+            _ = _dependency;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class SpecializedMinimalEventHandler : IEventHandler<string, SpecializedEventContext>
+    {
+        public static SpecializedEventContext? ReceivedContext { get; set; }
+
+        public ValueTask HandleAsync(string input, SpecializedEventContext context, CancellationToken cancellationToken)
+        {
+            ReceivedContext = context;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Tests.Lambda.Template/MinimalFunctionTests.cs
+++ b/tests/Tests.Lambda.Template/MinimalFunctionTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,6 +28,7 @@ public class MinimalFunctionTests
         TrackingEventHandler.Reset();
         TrackingRequestHandler.Reset();
         ScopedTrackingHandler.ScopeIds.Clear();
+        ScopedRequestTrackingHandler.ScopeIds.Clear();
         AsyncDisposableDependency.WasDisposed = false;
     }
 
@@ -76,6 +80,35 @@ public class MinimalFunctionTests
     }
 
     [Test]
+    public async Task Minimal_functions_do_not_enrich_invocation_activity_or_record_framework_invocations()
+    {
+        var measurements = new ConcurrentBag<long>();
+
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == LambdaTelemetry.MeterName &&
+                instrument.Name == "kralizek.lambda.invocations")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        meterListener.Start();
+
+        using var invocation = new Activity("lambda-invocation").Start();
+
+        await new TrackingMinimalEventFunction().FunctionHandlerAsync("event", TestLambdaContexts.Create());
+        await new TrackingMinimalRequestFunction().FunctionHandlerAsync("request", TestLambdaContexts.Create());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(invocation.GetTagItem("kralizek.lambda.function.model"), Is.Null);
+            Assert.That(measurements, Is.Empty);
+        });
+    }
+
+    [Test]
     public void MinimalEventFunction_cancels_before_handler_when_no_execution_time_remains()
     {
         var sut = new TrackingMinimalEventFunction();
@@ -99,9 +132,32 @@ public class MinimalFunctionTests
     }
 
     [Test]
+    public async Task MinimalRequestFunction_creates_an_independent_scope_per_invocation()
+    {
+        var sut = new ScopedMinimalRequestFunction();
+        var context = TestLambdaContexts.Create();
+
+        await sut.FunctionHandlerAsync("first", context);
+        await sut.FunctionHandlerAsync("second", context);
+
+        Assert.That(ScopedRequestTrackingHandler.ScopeIds, Has.Count.EqualTo(2));
+        Assert.That(ScopedRequestTrackingHandler.ScopeIds[0], Is.Not.EqualTo(ScopedRequestTrackingHandler.ScopeIds[1]));
+    }
+
+    [Test]
     public async Task MinimalEventFunction_async_disposes_scoped_dependencies_after_handler_completion()
     {
         var sut = new AsyncDisposableMinimalEventFunction();
+
+        await sut.FunctionHandlerAsync("trigger", TestLambdaContexts.Create());
+
+        Assert.That(AsyncDisposableDependency.WasDisposed, Is.True);
+    }
+
+    [Test]
+    public async Task MinimalRequestFunction_async_disposes_scoped_dependencies_after_handler_completion()
+    {
+        var sut = new AsyncDisposableMinimalRequestFunction();
 
         await sut.FunctionHandlerAsync("trigger", TestLambdaContexts.Create());
 
@@ -142,7 +198,19 @@ public class MinimalFunctionTests
             services.AddScoped<ScopedDependency>();
     }
 
+    public sealed class ScopedMinimalRequestFunction : MinimalRequestFunction<string, string, ScopedRequestTrackingHandler>
+    {
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
+            services.AddScoped<ScopedDependency>();
+    }
+
     public sealed class AsyncDisposableMinimalEventFunction : MinimalEventFunction<string, AsyncDisposableHandler>
+    {
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
+            services.AddScoped<AsyncDisposableDependency>();
+    }
+
+    public sealed class AsyncDisposableMinimalRequestFunction : MinimalRequestFunction<string, string, AsyncDisposableRequestHandler>
     {
         protected override void ConfigureServices(IServiceCollection services, IConfiguration configuration) =>
             services.AddScoped<AsyncDisposableDependency>();
@@ -216,6 +284,21 @@ public class MinimalFunctionTests
         }
     }
 
+    public sealed class ScopedRequestTrackingHandler : IRequestHandler<string, string>
+    {
+        private readonly ScopedDependency _dependency;
+
+        public ScopedRequestTrackingHandler(ScopedDependency dependency) => _dependency = dependency;
+
+        public static List<Guid> ScopeIds { get; } = [];
+
+        public ValueTask<string> HandleAsync(string input, RequestContext context, CancellationToken cancellationToken)
+        {
+            ScopeIds.Add(_dependency.Id);
+            return ValueTask.FromResult(input);
+        }
+    }
+
     public sealed class AsyncDisposableDependency : IAsyncDisposable
     {
         public static bool WasDisposed { get; set; }
@@ -237,6 +320,19 @@ public class MinimalFunctionTests
         {
             _ = _dependency;
             return ValueTask.CompletedTask;
+        }
+    }
+
+    public sealed class AsyncDisposableRequestHandler : IRequestHandler<string, string>
+    {
+        private readonly AsyncDisposableDependency _dependency;
+
+        public AsyncDisposableRequestHandler(AsyncDisposableDependency dependency) => _dependency = dependency;
+
+        public ValueTask<string> HandleAsync(string input, RequestContext context, CancellationToken cancellationToken)
+        {
+            _ = _dependency;
+            return ValueTask.FromResult(input);
         }
     }
 


### PR DESCRIPTION
Closes #103.

Introduces `MinimalLambdaFunction` plus minimal request/event hosts as an alternative hosting model for the existing v6 handler contracts. Minimal hosting preserves configuration, logging, function-local DI, invocation scopes, v6 contexts, cancellation, and async scope disposal while omitting the full host's internal invocation telemetry and source-specific processing machinery.

Also adds:

- dedicated Minimal Request/Event samples and documentation;
- `--minimal` support for the generic Request/Event templates, including OpenTelemetry and Native AOT composition;
- JSON-driven template smoke-test coverage using the existing CI infrastructure;
- Request benchmarks comparing Raw SDK, V5, V6 Minimal, and V6 full;
- benchmark-only V6 Minimal SQS competitors implemented as `MinimalRequestFunction<SQSEvent, SQSBatchResponse, ...>` with application-owned SQS iteration/decoding/response handling;
- corresponding Minimal competitors for synchronous/asynchronous SQS, partial-batch returned/exception failures, and nested SQS -> SNS -> S3 processing.

The SQS benchmark compositions are comparison fixtures only; this PR does not add a `MinimalSqsFunction` or other source-specific Minimal product API. The beta-4 controlled V5 -> full-V6 benchmark reference remains preserved as a historical baseline, while the expanded benchmark matrix is ready for a new controlled-hardware analysis including Minimal hosting.

Validated by the full CI/template matrix, benchmark validation, and SonarQube quality gate.