### PR TITLE
Pre-size record result collections

### DIFF
--- a/src/Kralizek.Lambda.Template/RecordFunction.cs
+++ b/src/Kralizek.Lambda.Template/RecordFunction.cs
@@ -144,10 +144,13 @@ public abstract class RecordFunction<TEnvelope, TRecord, TRecordResult, TRespons
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var results = new List<RecordProcessingResult>();
+        var records = GetRecords(envelope);
+        var results = records.TryGetNonEnumeratedCount(out var recordCount)
+            ? new List<RecordProcessingResult>(recordCount)
+            : new List<RecordProcessingResult>();
         var processor = invocationServices.GetRequiredService<IRecordProcessor<TRecord, TRecordResult, TContext>>();
 
-        foreach (var record in GetRecords(envelope))
+        foreach (var record in records)
         {
             cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
## What changed

- Captures the sequential record enumerable once in `RecordFunction.ProcessRecordsAsync`.
- Uses `TryGetNonEnumeratedCount` to pre-size the `RecordProcessingResult` list when the record source exposes a cheap count.
- Preserves streaming enumeration and the existing zero-capacity behavior when the count cannot be determined without enumeration.

## Why

The controlled benchmark investigation identified result-list growth as a small avoidable allocation in the per-record pipeline. AWS event envelopes generally expose record collections with a known count, so the sequential path can avoid intermediate `List<T>` growth without changing record-processing semantics.

The parallel path already materializes the records and allocates its result array at the exact size; this change brings the sequential path closer to that allocation behavior without forcing materialization.

## Semantics

- record order is unchanged
- `GetRecords` is called once per sequential processing pass
- records are still processed sequentially and lazily
- one DI scope per record is unchanged
- cancellation, exception translation, partial-batch behavior, contexts, telemetry, and disposal semantics are unchanged

## Validation

CI should validate the normal build/test/format flow. The existing SQS batch benchmarks, especially batch 100 allocation measurements, can be used to quantify the expected small reduction separately.