### PR TITLE
Simplify benchmark workflow entry points

### DIFF
--- a/.github/workflows/benchmark-history.yml
+++ b/.github/workflows/benchmark-history.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+    inputs:
+      publish_history:
+        description: Publish results to benchmark history
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: benchmark-history-${{ github.ref }}
@@ -11,11 +17,11 @@ concurrency:
 
 jobs:
   benchmark:
-    name: Run and publish benchmarks
+    name: Run benchmarks
     permissions:
       actions: read
       contents: write
     uses: ./.github/workflows/release-benchmarks.yml
     with:
-      publish-history: true
+      publish-history: ${{ github.event_name == 'push' || inputs.publish_history }}
       release-mode: false

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -18,7 +18,6 @@ on:
         required: false
         type: string
         default: ''
-  workflow_dispatch:
 
 jobs:
   snapshot:


### PR DESCRIPTION
## Summary

- make `Benchmark snapshot` reusable-only by removing its manual dispatch trigger
- keep `Benchmark history` as the single manual benchmark entry point
- add a `publish_history` input for manual runs, defaulting to `false`
- continue publishing benchmark history automatically on pushes to `master`

## Behavior

- push to `master`: run benchmarks and publish history
- manual `Benchmark history` run: run benchmarks without publishing history by default
- manual run with `publish_history` enabled: run benchmarks and publish history
- release pipeline: continues to call the reusable benchmark snapshot workflow as before
