### PR TITLE
Reduce root function-context allocations

### DIFF
--- a/.github/workflows/benchmark-history.yml
+++ b/.github/workflows/benchmark-history.yml
@@ -5,6 +5,15 @@ on:
     branches: [master]
   workflow_dispatch:
     inputs:
+      profile:
+        description: Benchmark profile to run
+        type: choice
+        required: true
+        default: ci
+        options:
+          - ci
+          - full
+          - stress
       publish_history:
         description: Publish results to benchmark history
         type: boolean
@@ -23,5 +32,6 @@ jobs:
       contents: write
     uses: ./.github/workflows/release-benchmarks.yml
     with:
+      benchmark-profile: ${{ github.event_name == 'workflow_dispatch' && inputs.profile || 'ci' }}
       publish-history: ${{ github.event_name == 'push' || inputs.publish_history }}
       release-mode: false

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ''
+      benchmark-profile:
+        description: Benchmark profile to run
+        required: false
+        type: string
+        default: ci
 
 jobs:
   snapshot:
@@ -46,7 +51,7 @@ jobs:
           --project Benchmarks/Benchmarks.csproj
           --configuration Release
           --
-          --profile ci
+          --profile ${{ inputs.benchmark-profile }}
           --filter '*'
           --exporters json
           --artifacts "$RUNNER_TEMP/BenchmarkDotNet.Artifacts"

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -26,7 +26,7 @@ public abstract class FunctionContext
     protected FunctionContext(
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
-        : this(metadata, CreatePropertySnapshot(properties))
+        : this(metadata, CreatePropertySnapshot(properties), PropertyStorage.Immutable)
     {
     }
 
@@ -34,7 +34,7 @@ public abstract class FunctionContext
         FunctionContextMetadata metadata,
         string propertyName,
         object? propertyValue)
-        : this(metadata, new SinglePropertyDictionary(propertyName, propertyValue))
+        : this(metadata, new SinglePropertyDictionary(propertyName, propertyValue), PropertyStorage.Immutable)
     {
     }
 
@@ -65,7 +65,8 @@ public abstract class FunctionContext
 
     private FunctionContext(
         FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties)
+        IReadOnlyDictionary<string, object?> properties,
+        PropertyStorage _)
     {
         ArgumentNullException.ThrowIfNull(metadata);
 
@@ -154,6 +155,11 @@ public abstract class FunctionContext
             firstPropertyValue,
             secondPropertyName,
             secondPropertyValue);
+    }
+
+    private enum PropertyStorage
+    {
+        Immutable
     }
 
     private sealed class SinglePropertyDictionary : IReadOnlyDictionary<string, object?>

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -26,16 +26,20 @@ public abstract class FunctionContext
     protected FunctionContext(
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
-        : this(metadata, CreatePropertySnapshot(properties), PropertyStorage.Immutable)
     {
-    }
+        ArgumentNullException.ThrowIfNull(metadata);
 
-    protected FunctionContext(
-        FunctionContextMetadata metadata,
-        string propertyName,
-        object? propertyValue)
-        : this(metadata, new SinglePropertyDictionary(propertyName, propertyValue), PropertyStorage.Immutable)
-    {
+        AwsRequestId = metadata.AwsRequestId;
+        FunctionName = metadata.FunctionName;
+        FunctionVersion = metadata.FunctionVersion;
+        InvokedFunctionArn = metadata.InvokedFunctionArn;
+        MemoryLimitInMB = metadata.MemoryLimitInMB;
+        RemainingTime = metadata.RemainingTime;
+        LogGroupName = metadata.LogGroupName;
+        LogStreamName = metadata.LogStreamName;
+        Properties = properties is SinglePropertyDictionary
+            ? properties
+            : CreatePropertySnapshot(properties);
     }
 
     protected FunctionContext(
@@ -61,24 +65,6 @@ public abstract class FunctionContext
                 secondPropertyName,
                 secondPropertyValue))
     {
-    }
-
-    private FunctionContext(
-        FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties,
-        PropertyStorage _)
-    {
-        ArgumentNullException.ThrowIfNull(metadata);
-
-        AwsRequestId = metadata.AwsRequestId;
-        FunctionName = metadata.FunctionName;
-        FunctionVersion = metadata.FunctionVersion;
-        InvokedFunctionArn = metadata.InvokedFunctionArn;
-        MemoryLimitInMB = metadata.MemoryLimitInMB;
-        RemainingTime = metadata.RemainingTime;
-        LogGroupName = metadata.LogGroupName;
-        LogStreamName = metadata.LogStreamName;
-        Properties = properties;
     }
 
     private FunctionContext(FunctionContext source, IReadOnlyDictionary<string, object?> properties)
@@ -116,6 +102,14 @@ public abstract class FunctionContext
     /// Gets additional runtime-specific data that is not represented by the strongly typed properties.
     /// </summary>
     public IReadOnlyDictionary<string, object?> Properties { get; }
+
+    /// <summary>
+    /// Creates an immutable one-property state bag that can be retained directly by a context.
+    /// </summary>
+    protected static IReadOnlyDictionary<string, object?> CreateImmutableProperties(
+        string propertyName,
+        object? propertyValue) =>
+        new SinglePropertyDictionary(propertyName, propertyValue);
 
     private static IReadOnlyDictionary<string, object?> CreatePropertySnapshot(
         IReadOnlyDictionary<string, object?>? properties)
@@ -155,11 +149,6 @@ public abstract class FunctionContext
             firstPropertyValue,
             secondPropertyName,
             secondPropertyValue);
-    }
-
-    private enum PropertyStorage
-    {
-        Immutable
     }
 
     private sealed class SinglePropertyDictionary : IReadOnlyDictionary<string, object?>
@@ -407,12 +396,6 @@ public class EventContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
-
-    protected EventContext(
-        FunctionContextMetadata metadata,
-        string propertyName,
-        object? propertyValue)
-        : base(metadata, propertyName, propertyValue) { }
 }
 
 /// <summary>
@@ -424,12 +407,6 @@ public class RequestContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
-
-    protected RequestContext(
-        FunctionContextMetadata metadata,
-        string propertyName,
-        object? propertyValue)
-        : base(metadata, propertyName, propertyValue) { }
 }
 
 /// <summary>
@@ -441,12 +418,6 @@ public class RecordContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
-
-    protected RecordContext(
-        FunctionContextMetadata metadata,
-        string propertyName,
-        object? propertyValue)
-        : base(metadata, propertyName, propertyValue) { }
 
     protected RecordContext(
         RecordContext source,

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -183,14 +183,28 @@ public abstract class FunctionContext
         }
 
         public object? this[string key]
-            => string.Equals(key, _propertyName, StringComparison.Ordinal)
-                ? _propertyValue
-                : throw new KeyNotFoundException();
+        {
+            get
+            {
+                ArgumentNullException.ThrowIfNull(key);
 
-        public bool ContainsKey(string key) => string.Equals(key, _propertyName, StringComparison.Ordinal);
+                return string.Equals(key, _propertyName, StringComparison.Ordinal)
+                    ? _propertyValue
+                    : throw new KeyNotFoundException();
+            }
+        }
+
+        public bool ContainsKey(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+
+            return string.Equals(key, _propertyName, StringComparison.Ordinal);
+        }
 
         public bool TryGetValue(string key, out object? value)
         {
+            ArgumentNullException.ThrowIfNull(key);
+
             if (string.Equals(key, _propertyName, StringComparison.Ordinal))
             {
                 value = _propertyValue;

--- a/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
+++ b/src/Kralizek.Lambda.Template.Abstractions/FunctionContext.cs
@@ -26,23 +26,16 @@ public abstract class FunctionContext
     protected FunctionContext(
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
+        : this(metadata, CreatePropertySnapshot(properties))
     {
-        ArgumentNullException.ThrowIfNull(metadata);
+    }
 
-        AwsRequestId = metadata.AwsRequestId;
-        FunctionName = metadata.FunctionName;
-        FunctionVersion = metadata.FunctionVersion;
-        InvokedFunctionArn = metadata.InvokedFunctionArn;
-        MemoryLimitInMB = metadata.MemoryLimitInMB;
-        RemainingTime = metadata.RemainingTime;
-        LogGroupName = metadata.LogGroupName;
-        LogStreamName = metadata.LogStreamName;
-
-        var propertySnapshot = properties is null
-            ? new Dictionary<string, object?>()
-            : new Dictionary<string, object?>(properties);
-
-        Properties = new ReadOnlyDictionary<string, object?>(propertySnapshot);
+    protected FunctionContext(
+        FunctionContextMetadata metadata,
+        string propertyName,
+        object? propertyValue)
+        : this(metadata, new SinglePropertyDictionary(propertyName, propertyValue))
+    {
     }
 
     protected FunctionContext(
@@ -68,6 +61,23 @@ public abstract class FunctionContext
                 secondPropertyName,
                 secondPropertyValue))
     {
+    }
+
+    private FunctionContext(
+        FunctionContextMetadata metadata,
+        IReadOnlyDictionary<string, object?> properties)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        AwsRequestId = metadata.AwsRequestId;
+        FunctionName = metadata.FunctionName;
+        FunctionVersion = metadata.FunctionVersion;
+        InvokedFunctionArn = metadata.InvokedFunctionArn;
+        MemoryLimitInMB = metadata.MemoryLimitInMB;
+        RemainingTime = metadata.RemainingTime;
+        LogGroupName = metadata.LogGroupName;
+        LogStreamName = metadata.LogStreamName;
+        Properties = properties;
     }
 
     private FunctionContext(FunctionContext source, IReadOnlyDictionary<string, object?> properties)
@@ -106,6 +116,16 @@ public abstract class FunctionContext
     /// </summary>
     public IReadOnlyDictionary<string, object?> Properties { get; }
 
+    private static IReadOnlyDictionary<string, object?> CreatePropertySnapshot(
+        IReadOnlyDictionary<string, object?>? properties)
+    {
+        var propertySnapshot = properties is null
+            ? new Dictionary<string, object?>()
+            : new Dictionary<string, object?>(properties);
+
+        return new ReadOnlyDictionary<string, object?>(propertySnapshot);
+    }
+
     private static IReadOnlyDictionary<string, object?> CreatePropertyOverlay(
         FunctionContext source,
         string propertyName,
@@ -134,6 +154,64 @@ public abstract class FunctionContext
             firstPropertyValue,
             secondPropertyName,
             secondPropertyValue);
+    }
+
+    private sealed class SinglePropertyDictionary : IReadOnlyDictionary<string, object?>
+    {
+        private readonly string _propertyName;
+        private readonly object? _propertyValue;
+
+        public SinglePropertyDictionary(string propertyName, object? propertyValue)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
+
+            _propertyName = propertyName;
+            _propertyValue = propertyValue;
+        }
+
+        public int Count => 1;
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                yield return _propertyName;
+            }
+        }
+
+        public IEnumerable<object?> Values
+        {
+            get
+            {
+                yield return _propertyValue;
+            }
+        }
+
+        public object? this[string key]
+            => string.Equals(key, _propertyName, StringComparison.Ordinal)
+                ? _propertyValue
+                : throw new KeyNotFoundException();
+
+        public bool ContainsKey(string key) => string.Equals(key, _propertyName, StringComparison.Ordinal);
+
+        public bool TryGetValue(string key, out object? value)
+        {
+            if (string.Equals(key, _propertyName, StringComparison.Ordinal))
+            {
+                value = _propertyValue;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            yield return new KeyValuePair<string, object?>(_propertyName, _propertyValue);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
 #pragma warning disable S3267 // Explicit loops avoid LINQ iterator allocations on this per-record hot path.
@@ -323,6 +401,12 @@ public class EventContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
+
+    protected EventContext(
+        FunctionContextMetadata metadata,
+        string propertyName,
+        object? propertyValue)
+        : base(metadata, propertyName, propertyValue) { }
 }
 
 /// <summary>
@@ -334,6 +418,12 @@ public class RequestContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
+
+    protected RequestContext(
+        FunctionContextMetadata metadata,
+        string propertyName,
+        object? propertyValue)
+        : base(metadata, propertyName, propertyValue) { }
 }
 
 /// <summary>
@@ -345,6 +435,12 @@ public class RecordContext : FunctionContext
         FunctionContextMetadata metadata,
         IReadOnlyDictionary<string, object?>? properties = null)
         : base(metadata, properties) { }
+
+    protected RecordContext(
+        FunctionContextMetadata metadata,
+        string propertyName,
+        object? propertyValue)
+        : base(metadata, propertyName, propertyValue) { }
 
     protected RecordContext(
         RecordContext source,

--- a/src/Kralizek.Lambda.Template/FunctionContextFactory.cs
+++ b/src/Kralizek.Lambda.Template/FunctionContextFactory.cs
@@ -16,19 +16,19 @@ public static class FunctionContextFactory
     public static EventContext CreateEventContext(ILambdaContext lambdaContext)
     {
         ArgumentNullException.ThrowIfNull(lambdaContext);
-        return new DefaultEventContext(CreateMetadata(lambdaContext), CreateProperties(lambdaContext));
+        return new DefaultEventContext(CreateMetadata(lambdaContext), LambdaContextPropertyName, lambdaContext);
     }
 
     public static RequestContext CreateRequestContext(ILambdaContext lambdaContext)
     {
         ArgumentNullException.ThrowIfNull(lambdaContext);
-        return new DefaultRequestContext(CreateMetadata(lambdaContext), CreateProperties(lambdaContext));
+        return new DefaultRequestContext(CreateMetadata(lambdaContext), LambdaContextPropertyName, lambdaContext);
     }
 
     public static RecordContext CreateRecordContext(ILambdaContext lambdaContext)
     {
         ArgumentNullException.ThrowIfNull(lambdaContext);
-        return new DefaultRecordContext(CreateMetadata(lambdaContext), CreateProperties(lambdaContext));
+        return new DefaultRecordContext(CreateMetadata(lambdaContext), LambdaContextPropertyName, lambdaContext);
     }
 
     /// <summary>
@@ -92,16 +92,19 @@ public static class FunctionContextFactory
 
     private sealed class DefaultEventContext(
         FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties)
-        : EventContext(metadata, properties);
+        string propertyName,
+        object? propertyValue)
+        : EventContext(metadata, propertyName, propertyValue);
 
     private sealed class DefaultRequestContext(
         FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties)
-        : RequestContext(metadata, properties);
+        string propertyName,
+        object? propertyValue)
+        : RequestContext(metadata, propertyName, propertyValue);
 
     private sealed class DefaultRecordContext(
         FunctionContextMetadata metadata,
-        IReadOnlyDictionary<string, object?> properties)
-        : RecordContext(metadata, properties);
+        string propertyName,
+        object? propertyValue)
+        : RecordContext(metadata, propertyName, propertyValue);
 }

--- a/src/Kralizek.Lambda.Template/FunctionContextFactory.cs
+++ b/src/Kralizek.Lambda.Template/FunctionContextFactory.cs
@@ -94,17 +94,17 @@ public static class FunctionContextFactory
         FunctionContextMetadata metadata,
         string propertyName,
         object? propertyValue)
-        : EventContext(metadata, propertyName, propertyValue);
+        : EventContext(metadata, CreateImmutableProperties(propertyName, propertyValue));
 
     private sealed class DefaultRequestContext(
         FunctionContextMetadata metadata,
         string propertyName,
         object? propertyValue)
-        : RequestContext(metadata, propertyName, propertyValue);
+        : RequestContext(metadata, CreateImmutableProperties(propertyName, propertyValue));
 
     private sealed class DefaultRecordContext(
         FunctionContextMetadata metadata,
         string propertyName,
         object? propertyValue)
-        : RecordContext(metadata, propertyName, propertyValue);
+        : RecordContext(metadata, CreateImmutableProperties(propertyName, propertyValue));
 }

--- a/tests/Tests.Lambda.Template/FunctionContextTests.cs
+++ b/tests/Tests.Lambda.Template/FunctionContextTests.cs
@@ -32,6 +32,23 @@ public class FunctionContextTests
     }
 
     [Test]
+    public void Factory_root_properties_are_immutable_and_fully_enumerable()
+    {
+        var lambdaContext = TestLambdaContexts.Create();
+
+        var context = FunctionContextFactory.CreateRequestContext(lambdaContext);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.Properties, Is.Not.AssignableTo<IDictionary<string, object?>>());
+            Assert.That(context.Properties.Count, Is.EqualTo(1));
+            Assert.That(context.Properties.Values.Single(), Is.SameAs(lambdaContext));
+            Assert.That(context.Properties.Single().Value, Is.SameAs(lambdaContext));
+            Assert.That(context.GetLambdaContext(), Is.SameAs(lambdaContext));
+        });
+    }
+
+    [Test]
     public void Semantic_contexts_can_be_specialized_without_accepting_lambda_context()
     {
         var lambdaContext = TestLambdaContexts.Create();

--- a/tests/Tests.Lambda.Template/FunctionContextTests.cs
+++ b/tests/Tests.Lambda.Template/FunctionContextTests.cs
@@ -49,6 +49,19 @@ public class FunctionContextTests
     }
 
     [Test]
+    public void Factory_root_properties_match_dictionary_null_key_behavior()
+    {
+        var context = FunctionContextFactory.CreateRequestContext(TestLambdaContexts.Create());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => { _ = context.Properties[null!]; }, Throws.ArgumentNullException);
+            Assert.That(() => { _ = context.Properties.ContainsKey(null!); }, Throws.ArgumentNullException);
+            Assert.That(() => { _ = context.Properties.TryGetValue(null!, out _); }, Throws.ArgumentNullException);
+        });
+    }
+
+    [Test]
     public void Semantic_contexts_can_be_specialized_without_accepting_lambda_context()
     {
         var lambdaContext = TestLambdaContexts.Create();


### PR DESCRIPTION
## What changed

- adds a compact immutable single-property state representation inside `FunctionContext` for framework-owned root context state;
- adds protected one-property constructors to the source-neutral Event, Request, and Record context types;
- updates `FunctionContextFactory` to preserve the original `ILambdaContext` through that compact state instead of `Dictionary -> defensive Dictionary copy -> ReadOnlyDictionary`;
- keeps the existing arbitrary-property constructor path unchanged, including its defensive snapshot semantics for custom/derived contexts;
- leaves the existing `PropertyOverlay` and all source-specific/nested record-context behavior unchanged;
- adds focused coverage that factory-created root state remains effectively immutable, enumerable, and compatible with `GetLambdaContext()`.

## Why

The focused `FunctionContext` allocation investigation found that root Request/Event/Record context creation allocates 560 B, with about 472 B attributable to property-bag machinery around a single framework-owned value. A benchmark-local prototype of a compact one-property state reduced the equivalent root context from 560 B to 120 B and improved root-state lookup without weakening the abstraction boundary.

The abstraction package remains unaware of `Amazon.Lambda.Core`: it stores only a string key and `object?` value. `FunctionContext.Properties` remains the opaque cross-package state mechanism used by runtime and source-specific packages.

## Preserved semantics

- existing public/protected dictionary-based construction remains available;
- caller-owned property dictionaries are still defensively snapshotted;
- factory-created state cannot be cast back to a mutable `Dictionary`;
- source-specific raw-record/origin propagation continues to use the existing overlays;
- no source-specific package behavior is changed.

## Expected performance effect

The disposable prototype measured:

- current root RequestContext: ~560 B;
- compact root Request-style context: ~120 B;
- expected saving: ~440 B per Request/Event/root Record invocation;
- projected allocation reduction: ~35.7% for the current full Request benchmark and ~39.9% for Minimal Request.

This PR puts the approach into production code so CI and follow-up controlled benchmarks can validate the real implementation before broader tests/docs/benchmark references are aligned.

## Scope

This PR is intentionally focused on the production root-state representation and its direct behavior tests. Samples, documentation, and benchmark reference material are left for follow-up once the implementation and measured effect are accepted.