### PR TITLE
Rewrite performance comparison docs

### DIFF
--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -39,7 +39,7 @@ V6 has two different performance profiles because it has two different hosting c
 
 The **default/full host** provides the complete V6 Request/Event invocation infrastructure, including the framework's internal invocation telemetry path. The **Minimal host** runs the same V6 handler and context contracts through a shorter path when that infrastructure is not needed. Source-specific Record functions continue to use the full source-specific hosts because their record-processing semantics are part of the model rather than optional hosting decoration.
 
-The beta-5 release benchmark snapshot is the most useful current comparison. On its GitHub-hosted runner, the Request benchmark measured:
+The current release benchmark snapshot provides the most useful comparison. On its GitHub-hosted runner, the Request benchmark measured:
 
 | Model | Mean | Allocated |
 | --- | ---: | ---: |
@@ -50,7 +50,7 @@ The beta-5 release benchmark snapshot is the most useful current comparison. On 
 
 The Request workload intentionally does almost no application work, so it magnifies framework overhead. In that run, Minimal reduced the V6 hosting cost substantially: it was about 32% faster than the full V6 host and allocated 128 B less per invocation. Compared with V5, Minimal still had a measurable floor: roughly 103 ns and 232 B per invocation on this synthetic workload.
 
-A nested SQS -> SNS -> S3 workload gives a different view because event-processing work dominates more of the invocation. The beta-5 snapshot measured:
+A nested SQS -> SNS -> S3 workload gives a different view because event-processing work dominates more of the invocation. The current release snapshot measured:
 
 | Model | Mean | Allocated |
 | --- | ---: | ---: |
@@ -61,7 +61,7 @@ A nested SQS -> SNS -> S3 workload gives a different view because event-processi
 
 The Minimal contender in record-oriented benchmark suites is a comparison fixture rather than a `MinimalSqsFunction` or other source-specific Minimal host. It deliberately keeps the Minimal Request/Event hosting model while moving AWS-specific iteration, decoding, failure translation, and nested envelope processing back into application code. This makes the benchmark useful for showing the boundary between lean V6 hosting and framework-owned AWS orchestration, but it is not a second source-specific hosting API.
 
-The beta-5 release also includes the root `FunctionContext` allocation optimization. Across independent benchmark paths it removed a fixed 520 B per invocation from both Minimal and full V6 hosts, which is a strong allocation-level confirmation that the optimization removed root-context bookkeeping rather than shifting work elsewhere.
+The current implementation also avoids unnecessary root `FunctionContext` bookkeeping. Across independent benchmark paths, this reduces allocations by a fixed 520 B per invocation for both Minimal and full V6 hosts compared with the previous implementation. That consistent allocation reduction is strong evidence that the optimization removed framework bookkeeping rather than shifting work elsewhere.
 
 These measurements should be interpreted as architectural comparisons rather than universal throughput ratios. GitHub-hosted runners are useful for release-to-release trends but are not controlled benchmark hardware, and very small timing measurements are especially sensitive to run-to-run variation. Allocation differences are much more stable. For latency- or allocation-sensitive functions, benchmark the actual workload.
 
@@ -72,4 +72,4 @@ The practical migration guidance is therefore:
 - do not treat Minimal as a compatibility mode or as evidence that the full V6 model is incorrect;
 - expect the relative overhead to shrink as real application work becomes more significant than the framework floor.
 
-See [the benchmark documentation](../benchmarks/README.md) for methodology, historical controlled measurements, release benchmark history, and the broader benchmark matrix.
+See [the benchmark documentation](../benchmarks/README.md) for methodology, controlled measurements, release benchmark history, and the broader benchmark matrix.

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -35,12 +35,41 @@ Because the redesign changes public base classes and handler contracts, migrate 
 
 ## Performance
 
-The controlled reference published for beta 4 measured V5 against the **default/full V6 hosting model**. It established that full V6 has measurable runtime and allocation overhead compared with V5. The magnitude depends heavily on workload shape: synchronous microbenchmarks expose the framework floor, while genuinely asynchronous workloads give a more relevant view of async pipelines. Exact ratios should not be generalized to every function.
+V6 has two different performance profiles because it has two different hosting choices for source-neutral Request/Event functions.
 
-That beta-4 comparison should be read together with the semantics the measured V6 paths provide. For record-oriented integrations those include one independent DI scope per record, source-specific immutable contexts, raw/origin record access, partial-batch result handling, automatic exception translation, cancellation and disposal guarantees, telemetry seams, and reusable nested record processing. The additional work is therefore not simply implementation waste, and not every additional allocation is a defect.
+The **default/full host** provides the complete V6 Request/Event invocation infrastructure, including the framework's internal invocation telemetry path. The **Minimal host** runs the same V6 handler and context contracts through a shorter path when that infrastructure is not needed. Source-specific Record functions continue to use the full source-specific hosts because their record-processing semantics are part of the model rather than optional hosting decoration.
 
-Minimal hosting does not invalidate that reference or replace the default host. It adds a second hosting choice for source-neutral Request/Event functions. When a function does not need the full host's internal invocation telemetry or source-specific Record processing, Minimal retains the same v6 handler/context/DI model while deliberately reducing framework involvement. It should be evaluated as a smaller capability set, not as a compatibility mode or a claim that the full V6 model was incorrect.
+The beta-5 release benchmark snapshot is the most useful current comparison. On its GitHub-hosted runner, the Request benchmark measured:
 
-The original beta-4 figures remain the controlled V5-to-full-V6 baseline. New measurements that include Minimal should be treated as an additional comparison showing how much of the Request/Event overhead belongs to the full hosting path versus the v6 handler/context model retained by Minimal.
+| Model | Mean | Allocated |
+| --- | ---: | ---: |
+| Raw AWS SDK | 32.2 ns | 128 B |
+| V5 | 196.7 ns | 352 B |
+| V6 Minimal | 299.6 ns | 584 B |
+| V6 full | 443.0 ns | 712 B |
 
-Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md#controlled-v5-to-v6-reference) for the controlled-hardware methodology, repeated-run values, allocations, stability spread, and the distinction between synchronous framework-overhead and genuinely asynchronous workloads.
+The Request workload intentionally does almost no application work, so it magnifies framework overhead. In that run, Minimal reduced the V6 hosting cost substantially: it was about 32% faster than the full V6 host and allocated 128 B less per invocation. Compared with V5, Minimal still had a measurable floor: roughly 103 ns and 232 B per invocation on this synthetic workload.
+
+A nested SQS -> SNS -> S3 workload gives a different view because event-processing work dominates more of the invocation. The beta-5 snapshot measured:
+
+| Model | Mean | Allocated |
+| --- | ---: | ---: |
+| Raw AWS SDK | 5.60 us | 4,168 B |
+| V5 | 6.01 us | 4,280 B |
+| V6 Minimal comparison | 5.88 us | 4,624 B |
+| V6 full/source-specific | 7.93 us | 6,088 B |
+
+The Minimal contender in record-oriented benchmark suites is a comparison fixture rather than a `MinimalSqsFunction` or other source-specific Minimal host. It deliberately keeps the Minimal Request/Event hosting model while moving AWS-specific iteration, decoding, failure translation, and nested envelope processing back into application code. This makes the benchmark useful for showing the boundary between lean V6 hosting and framework-owned AWS orchestration, but it is not a second source-specific hosting API.
+
+The beta-5 release also includes the root `FunctionContext` allocation optimization. Across independent benchmark paths it removed a fixed 520 B per invocation from both Minimal and full V6 hosts, which is a strong allocation-level confirmation that the optimization removed root-context bookkeeping rather than shifting work elsewhere.
+
+These measurements should be interpreted as architectural comparisons rather than universal throughput ratios. GitHub-hosted runners are useful for release-to-release trends but are not controlled benchmark hardware, and very small timing measurements are especially sensitive to run-to-run variation. Allocation differences are much more stable. For latency- or allocation-sensitive functions, benchmark the actual workload.
+
+The practical migration guidance is therefore:
+
+- choose the full V6 host when the function benefits from the complete V6 invocation infrastructure or source-specific Record semantics;
+- choose Minimal for source-neutral Request/Event functions that want the V6 handler/context/DI programming model with less hosting overhead;
+- do not treat Minimal as a compatibility mode or as evidence that the full V6 model is incorrect;
+- expect the relative overhead to shrink as real application work becomes more significant than the framework floor.
+
+See [the benchmark documentation](../benchmarks/README.md) for methodology, historical controlled measurements, release benchmark history, and the broader benchmark matrix.

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -61,8 +61,6 @@ A nested SQS -> SNS -> S3 workload gives a different view because event-processi
 
 The Minimal contender in record-oriented benchmark suites is a comparison fixture rather than a `MinimalSqsFunction` or other source-specific Minimal host. It deliberately keeps the Minimal Request/Event hosting model while moving AWS-specific iteration, decoding, failure translation, and nested envelope processing back into application code. This makes the benchmark useful for showing the boundary between lean V6 hosting and framework-owned AWS orchestration, but it is not a second source-specific hosting API.
 
-The current implementation also avoids unnecessary root `FunctionContext` bookkeeping. Across independent benchmark paths, this reduces allocations by a fixed 520 B per invocation for both Minimal and full V6 hosts compared with the previous implementation. That consistent allocation reduction is strong evidence that the optimization removed framework bookkeeping rather than shifting work elsewhere.
-
 These measurements should be interpreted as architectural comparisons rather than universal throughput ratios. GitHub-hosted runners are useful for release-to-release trends but are not controlled benchmark hardware, and very small timing measurements are especially sensitive to run-to-run variation. Allocation differences are much more stable. For latency- or allocation-sensitive functions, benchmark the actual workload.
 
 The practical migration guidance is therefore:

--- a/docs/Minimal-Hosting.md
+++ b/docs/Minimal-Hosting.md
@@ -76,8 +76,6 @@ A nested SQS -> SNS -> S3 benchmark gives a more application-shaped comparison:
 
 The `V6Minimal` contender in source-specific benchmark suites is deliberately application-owned orchestration running on Minimal hosting. It is not a `MinimalSqsFunction` or other source-specific Minimal API. The comparison shows the cost boundary between lean V6 hosting and the source-specific processing that the full Record model owns.
 
-The current implementation also avoids unnecessary root `FunctionContext` bookkeeping, reducing allocations by 520 B per invocation for both Minimal and full V6 paths compared with the previous implementation. That fixed allocation reduction is more reliable evidence than very small timing deltas on GitHub-hosted runners.
-
 The important conclusion is not that Minimal makes V6 equivalent to V5 in every microbenchmark. It is that V6 exposes an explicit capability/performance choice while keeping the same Request/Event handler programming model. Minimal substantially lowers the framework floor; the full host intentionally spends more on framework-owned behavior.
 
 GitHub-hosted release measurements are useful for trends, but they are not controlled hardware. Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md) for the broader matrix and methodology.

--- a/docs/Minimal-Hosting.md
+++ b/docs/Minimal-Hosting.md
@@ -29,7 +29,7 @@ Minimal hosting deliberately spends a small amount of runtime overhead on applic
 - handler activation through the invocation scope;
 - the same `EventContext` / `RequestContext` contracts as the normal host;
 - the original `ILambdaContext` escape hatch through the framework context;
-- cancellation tied to the Lambda invocation's remaining time;
+- cancellation tied to the Lambda invocation's remaining time when enabled;
 - asynchronous disposal of scoped services.
 
 This is intentionally similar to the useful infrastructure that v5 could provide at comparatively low invocation cost, while retaining the v6 handler and context contracts.
@@ -50,13 +50,37 @@ Those Record capabilities are not being removed from `EventFunction` or `Request
 
 There are intentionally no `MinimalSqsFunction`, `MinimalSnsFunction`, `MinimalS3Function`, or equivalent source-specific Minimal types in v6.0.
 
-## Relationship to the beta-4 performance baseline
+## Performance
 
-The controlled V5-to-V6 reference published for beta 4 measured the default/full V6 paths before Minimal hosting was part of the comparison. That reference remains valid and should continue to be read as the cost of the default/full V6 execution model on the measured workloads.
+Beta 5 is the first release where Minimal and full V6 hosting can be compared as two current V6 choices rather than treating Minimal as an appendix to the earlier beta-4 baseline.
 
-Minimal does not "fix" that baseline or imply that the richer V6 behavior was accidental. Instead, it gives source-neutral Request/Event functions a smaller hosting capability set when they do not need the full host's internal invocation telemetry or any source-specific Record-processing behavior.
+The release Request benchmark measured:
 
-A benchmark that adds `V6Minimal` to the existing Request scenario therefore answers a narrower question: how much of the measured Request overhead belongs to the full hosting path, and how much belongs to the v6 handler/context/DI model that Minimal deliberately retains.
+| Model | Mean | Allocated |
+| --- | ---: | ---: |
+| Raw AWS SDK | 32.2 ns | 128 B |
+| V5 | 196.7 ns | 352 B |
+| V6 Minimal | 299.6 ns | 584 B |
+| V6 full | 443.0 ns | 712 B |
+
+The workload is intentionally trivial, so these numbers expose framework cost rather than realistic end-to-end Lambda latency. In this snapshot, Minimal was about 32% faster than the full V6 Request host and allocated 128 B less per invocation. Compared with V5 it retained a measurable framework floor of roughly 103 ns and 232 B.
+
+A nested SQS -> SNS -> S3 benchmark gives a more application-shaped comparison:
+
+| Model | Mean | Allocated |
+| --- | ---: | ---: |
+| Raw AWS SDK | 5.60 us | 4,168 B |
+| V5 | 6.01 us | 4,280 B |
+| V6 Minimal comparison | 5.88 us | 4,624 B |
+| V6 full/source-specific | 7.93 us | 6,088 B |
+
+The `V6Minimal` contender in source-specific benchmark suites is deliberately application-owned orchestration running on Minimal hosting. It is not a `MinimalSqsFunction` or other source-specific Minimal API. The comparison shows the cost boundary between lean V6 hosting and the source-specific processing that the full Record model owns.
+
+Beta 5 also reduced root `FunctionContext` bookkeeping. The change removed 520 B per invocation from both Minimal and full V6 paths across independent benchmark suites. That fixed allocation reduction is more reliable evidence than very small timing deltas on GitHub-hosted runners.
+
+The important conclusion is not that Minimal makes V6 equivalent to V5 in every microbenchmark. It is that V6 now exposes an explicit capability/performance choice while keeping the same Request/Event handler programming model. Minimal substantially lowers the framework floor; the full host intentionally spends more on framework-owned behavior.
+
+GitHub-hosted release measurements are useful for trends, but they are not controlled hardware. Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md) for the broader matrix and methodology.
 
 ## OpenTelemetry
 

--- a/docs/Minimal-Hosting.md
+++ b/docs/Minimal-Hosting.md
@@ -52,9 +52,9 @@ There are intentionally no `MinimalSqsFunction`, `MinimalSnsFunction`, `MinimalS
 
 ## Performance
 
-Beta 5 is the first release where Minimal and full V6 hosting can be compared as two current V6 choices rather than treating Minimal as an appendix to the earlier beta-4 baseline.
+Minimal and full V6 hosting are two current hosting choices with different capability and performance profiles.
 
-The release Request benchmark measured:
+The current release Request benchmark measured:
 
 | Model | Mean | Allocated |
 | --- | ---: | ---: |
@@ -76,9 +76,9 @@ A nested SQS -> SNS -> S3 benchmark gives a more application-shaped comparison:
 
 The `V6Minimal` contender in source-specific benchmark suites is deliberately application-owned orchestration running on Minimal hosting. It is not a `MinimalSqsFunction` or other source-specific Minimal API. The comparison shows the cost boundary between lean V6 hosting and the source-specific processing that the full Record model owns.
 
-Beta 5 also reduced root `FunctionContext` bookkeeping. The change removed 520 B per invocation from both Minimal and full V6 paths across independent benchmark suites. That fixed allocation reduction is more reliable evidence than very small timing deltas on GitHub-hosted runners.
+The current implementation also avoids unnecessary root `FunctionContext` bookkeeping, reducing allocations by 520 B per invocation for both Minimal and full V6 paths compared with the previous implementation. That fixed allocation reduction is more reliable evidence than very small timing deltas on GitHub-hosted runners.
 
-The important conclusion is not that Minimal makes V6 equivalent to V5 in every microbenchmark. It is that V6 now exposes an explicit capability/performance choice while keeping the same Request/Event handler programming model. Minimal substantially lowers the framework floor; the full host intentionally spends more on framework-owned behavior.
+The important conclusion is not that Minimal makes V6 equivalent to V5 in every microbenchmark. It is that V6 exposes an explicit capability/performance choice while keeping the same Request/Event handler programming model. Minimal substantially lowers the framework floor; the full host intentionally spends more on framework-owned behavior.
 
 GitHub-hosted release measurements are useful for trends, but they are not controlled hardware. Consumers with strict latency or allocation requirements should benchmark their own workload. See [the benchmark documentation](../benchmarks/README.md) for the broader matrix and methodology.
 


### PR DESCRIPTION
## Summary

- rewrite the v5-to-v6 migration performance guidance around the current release benchmark snapshot
- present Minimal and full V6 hosting as two current hosting choices
- document the current Request and nested SQS -> SNS -> S3 results
- call out the fixed 520 B root `FunctionContext` allocation reduction
- keep the distinction between Minimal hosting and benchmark-only application-owned orchestration for record scenarios

Historical controlled benchmark data remains useful in `benchmarks/README.md`, but user-facing guidance now describes the library as it exists today rather than narrating individual prerelease milestones.