### PR TITLE
docs: add concrete v5 to v6 upgrade guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,125 +1,18 @@
-# Migrating from V5 to V6
+# Migrating from v5 to v6
 
-V6 is a redesign of the programming model rather than an incremental API update. Existing V5 functions should be migrated intentionally instead of relying on compatibility shims.
+The concrete v5-to-v6 upgrade guide now lives in [`docs/Migrating-from-v5-to-v6.md`](docs/Migrating-from-v5-to-v6.md).
 
-## Target framework
+It includes itemized before/after migrations for:
 
-V6 targets .NET 10. Update Lambda projects and deployment tooling accordingly before migrating application code.
+- Request/response functions;
+- Event functions;
+- SNS functions;
+- SQS functions;
+- configuration, logging, and dependency-injection hooks;
+- `ILambdaContext` replacement;
+- custom SNS/SQS payload serialization;
+- parallel record processing;
+- SQS partial-batch responses;
+- v6 full vs Minimal hosting.
 
-## Choose the semantic function model
-
-V6 organizes functions around three roots:
-
-- `EventFunction` for one-way events;
-- `RequestFunction` for request/response invocations;
-- `RecordFunction` for batched record sources.
-
-Source-specific packages build on those roots and should normally be preferred over the generic types when a supported AWS event source exists.
-
-## Function and handler responsibilities
-
-V6 separates the Lambda function declaration from application handler logic. The primary handler type is declared in the function generic arguments and resolved from dependency injection.
-
-Application handlers receive a framework context plus a `CancellationToken`. The framework owns invocation scopes and handler activation.
-
-Use `ConfigureServices`, `ConfigureConfiguration`, and `ConfigureLogging` for application customization. Do not register the primary handler manually unless you intentionally want to override its default scoped lifetime.
-
-## Contexts
-
-Handlers no longer need to depend directly on `ILambdaContext` for normal invocation metadata.
-
-Use the strongly typed framework context supplied to the handler. Source integrations expose richer derived contexts for source-specific metadata.
-
-When an AWS runtime object is intentionally not part of the stable abstraction, the original object is preserved in the context property bag and exposed through source-specific escape-hatch extensions.
-
-## Payload serialization and decoding
-
-The old source-specific serializer customization model has been replaced with payload decoders:
-
-- `IStringPayloadDecoder<TPayload>` for string payloads such as SQS and SNS message bodies;
-- `IBinaryPayloadDecoder<TPayload>` for binary payloads such as Kinesis records.
-
-JSON decoders are registered by default and can be replaced through dependency injection. The decoder abstractions also support source-generated System.Text.Json metadata for Native AOT scenarios.
-
-## SQS
-
-Use `SqsFunction<TMessage, THandler>` for decoded message bodies or `SqsFunction<THandler>` for raw records.
-
-SQS handlers return `SqsRecordResult` explicitly. Return `SqsRecordResult.Success` for successful records or `SqsRecordResult.Failed(...)` for records that should appear in the Lambda partial-batch response.
-
-Bounded in-process parallelism remains available through the explicit `ParallelSqsFunction` variants.
-
-Infrastructure must still configure the event source mapping appropriately for partial-batch responses.
-
-## SNS
-
-Use `SnsFunction<TNotification, THandler>` for decoded notifications or `SnsFunction<THandler>` for raw records.
-
-SNS handlers return `SnsRecordResult.Completed`. SNS does not support Lambda partial-batch responses, so an exception still fails the entire invocation.
-
-Bounded parallel processing is available only through the explicit `ParallelSnsFunction` variants.
-
-## DynamoDB Streams
-
-Use `DynamoDbStreamFunction<THandler>` from `Kralizek.Lambda.Template.DynamoDbStreams`.
-
-Handlers receive a `DynamoDbStreamItem` plus `DynamoDbStreamRecordContext` and return `DynamoDbStreamRecordResult`.
-
-Stream images use AWS `AttributeValue` dictionaries rather than pretending DynamoDB values are ordinary JSON.
-
-Processing inside one Lambda invocation is sequential by design. Configure the Lambda event source mapping `ParallelizationFactor` when additional concurrency is needed so Lambda preserves stream ordering semantics.
-
-## Kinesis Streams
-
-Use the Kinesis Streams package for raw `KinesisEventRecord` handling or decoded binary payload handling.
-
-Decoded handlers use `IBinaryPayloadDecoder<TPayload>` with JSON decoding registered by default. Handlers return `KinesisStreamRecordResult`.
-
-Like DynamoDB Streams, processing within one invocation is sequential. Configure event-source parallelism in Lambda rather than adding in-process parallelism.
-
-## EventBridge
-
-Use `EventBridgeFunction<TDetail, THandler>`. The Lambda runtime serializer materializes `CloudWatchEvent<TDetail>` and the handler receives the typed detail while retaining access to the event envelope through the EventBridge context.
-
-No additional payload decoder is involved.
-
-## Cognito
-
-V6 provides one strongly typed function base and handler interface for each supported Cognito user-pool trigger contract.
-
-Pre-token-generation V1 and V2 are distinct runtime contracts. The project template exposes them through the `--version v1|v2` option.
-
-## S3
-
-V6 adds `S3Function<THandler>` for S3 event notifications and `S3BatchFunction<THandler>` for S3 Batch Operations schema 2.0.
-
-The S3 integration exposes synthetic consumer-facing models while preserving access to the original AWS records through the source context.
-
-S3 Batch schema 1.0 and S3 Object Lambda are not supported by the initial V6 implementation.
-
-## Project templates
-
-The V5 Empty/Rich template split has been removed. V6 provides semantic and source-specific templates instead.
-
-Install the V6 template package and use `dotnet new list` to see the current template catalog. Generated projects reference the matching V6 runtime package version.
-
-## Package layout
-
-V6 includes a lightweight `Kralizek.Lambda.Template.Abstractions` package for consumer-facing contexts, handler contracts, record results, and decoder abstractions without bringing in the full runtime infrastructure.
-
-Source-specific functionality lives in dedicated packages such as SQS, SNS, S3, EventBridge, Cognito, DynamoDB Streams, and Kinesis Streams.
-
-## Recommended migration approach
-
-Migrate one Lambda function at a time:
-
-1. update the project to .NET 10 and V6 packages;
-2. select the matching V6 semantic or source-specific function type;
-3. move application logic into the corresponding handler contract;
-4. replace direct `ILambdaContext` usage with the framework/source context where possible;
-5. replace serializer hooks with payload decoders where applicable;
-6. return the source-specific record result for batched sources;
-7. review event-source mapping settings for partial-batch responses, retries, ordering, and parallelization;
-8. build and test the function before moving to the next one.
-
-See `CHANGELOG.md` for the complete V6 change summary and the package READMEs for source-specific behavior.
+See [`CHANGELOG.md`](CHANGELOG.md) for the complete v6 change summary.

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -19,8 +19,7 @@ Apply these changes to every migrated function first:
    - `Configure(...)` becomes `ConfigureConfiguration(...)`;
    - `ConfigureLogging(ILoggingBuilder, IExecutionEnvironment)` becomes `ConfigureLogging(ILoggingBuilder)`;
    - `ConfigureServices(IServiceCollection, IExecutionEnvironment)` becomes `ConfigureServices(IServiceCollection, IConfiguration)`.
-9. Preserve calls to the corresponding `base.Configure...(...)` methods unless you intentionally want to replace framework defaults.
-10. Build and run the function's tests before changing another integration.
+9. Build and run the function's tests before changing another integration.
 
 The sections below show the concrete v5-to-v6 transformation for the four most common v5 function shapes.
 
@@ -428,13 +427,11 @@ protected override void ConfigureConfiguration(
     IConfigurationBuilder configuration)
 {
     configuration.AddEnvironmentVariables();
-    base.ConfigureConfiguration(configuration);
 }
 
 protected override void ConfigureLogging(ILoggingBuilder logging)
 {
     // Add or customize logging here.
-    base.ConfigureLogging(logging);
 }
 
 protected override void ConfigureServices(
@@ -442,7 +439,6 @@ protected override void ConfigureServices(
     IConfiguration configuration)
 {
     services.AddScoped<IMyService, MyService>();
-    base.ConfigureServices(services, configuration);
 }
 ```
 

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -207,7 +207,7 @@ public sealed class RawSnsHandler : ISnsRecordHandler
 {
     public ValueTask<SnsRecordResult> HandleAsync(
         SNSEvent.SNSRecord record,
-        SnsRecordContext context,
+        SnsNotificationContext context,
         CancellationToken cancellationToken)
         => ValueTask.FromResult(SnsRecordResult.Completed);
 }
@@ -223,7 +223,15 @@ services
     .WithParallelExecution(maxDegreeOfParallelism: 4);
 ```
 
-In v6, parallel processing is explicit in the function type. Use the corresponding `ParallelSnsFunction<...>` variant and configure its supported degree of parallelism rather than chaining a registration extension.
+In v6, parallel processing is explicit in the function type:
+
+```csharp
+public sealed class Function
+    : ParallelSnsFunction<OrderCreated, OrderCreatedHandler>
+{
+    protected override int MaxDegreeOfParallelism => 4;
+}
+```
 
 Sequential processing is the default.
 
@@ -301,7 +309,7 @@ public sealed class RawSqsHandler : ISqsRecordHandler
 {
     public ValueTask<SqsRecordResult> HandleAsync(
         SQSEvent.SQSMessage record,
-        SqsRecordContext context,
+        SqsMessageContext context,
         CancellationToken cancellationToken)
         => ValueTask.FromResult(SqsRecordResult.Success);
 }
@@ -363,7 +371,17 @@ services
     .WithParallelExecution(maxDegreeOfParallelism: 4);
 ```
 
-In v6, choose the corresponding `ParallelSqsFunction<...>` variant. Sequential processing is the default.
+In v6, choose the corresponding parallel function variant:
+
+```csharp
+public sealed class Function
+    : ParallelSqsFunction<OrderCreated, OrderCreatedHandler>
+{
+    protected override int MaxDegreeOfParallelism => 4;
+}
+```
+
+Sequential processing is the default.
 
 ### SQS custom serialization
 
@@ -440,8 +458,8 @@ Use the supplied v6 context first:
 
 - `RequestContext` for Request functions;
 - `EventContext` for Event functions;
-- `SqsMessageContext` / `SqsRecordContext` for SQS;
-- `SnsNotificationContext` / `SnsRecordContext` for SNS.
+- `SqsMessageContext` for both typed and raw SQS handlers;
+- `SnsNotificationContext` for both typed and raw SNS handlers.
 
 These contexts expose the stable invocation/source metadata expected by application code. Source-specific contexts also preserve the original AWS records through escape-hatch extensions when needed.
 
@@ -475,7 +493,7 @@ public sealed class OrderCreatedDecoder
 {
     public ValueTask<OrderCreated> DecodeAsync(
         string payload,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         // Decode the payload.
     }

--- a/docs/Migrating-from-v5-to-v6.md
+++ b/docs/Migrating-from-v5-to-v6.md
@@ -1,45 +1,528 @@
 # Migrating from v5 to v6
 
-Version 6 is a programming-model redesign rather than a drop-in package update. Existing functions should be migrated deliberately.
+Version 6 is a programming-model redesign rather than a drop-in package update. This guide is intentionally mechanical: start from the v5 shape you have today and apply the matching changes below.
 
-The main conceptual changes are:
+Migrate one Lambda at a time. Get the function building and behaving correctly before moving to the next one.
 
-- Function classes select an Event, Request, or Record model while application logic lives in injected handlers.
-- AWS-specific integrations use dedicated packages and source-specific handler/context contracts.
-- Record handlers return source-specific `LambdaRecordResult` types instead of relying on implicit completion.
-- Payload decoding is separated from record transport through string/binary decoder contracts.
-- Framework contexts expose common Lambda metadata without requiring handlers to depend directly on `ILambdaContext`; the original AWS context remains available as an escape hatch.
-- Record processing owns one DI scope per record, with parallel processing exposed only by integrations where it is appropriate.
+## Upgrade checklist
 
-V6 also separates the request/event handler programming model from the amount of hosting infrastructure used to invoke it. `EventFunction` and `RequestFunction` remain the default/full hosts. `MinimalEventFunction` and `MinimalRequestFunction` invoke the same v6 handlers through a leaner path that retains configuration, logging, function-local dependency injection, one invocation scope, the v6 context, cancellation, and asynchronous scope disposal.
+Apply these changes to every migrated function first:
 
-This can be particularly relevant when migrating a simple v5 Event or Request/Response function. V5 already provided a function-local service provider and one DI scope per invocation with comparatively little runtime overhead. If the migrated function does not need the full Request/Event host's internal invocation telemetry or any source-specific record-processing behavior, consider the Minimal host after moving the application logic to the v6 handler contract.
+1. Target .NET 10.
+2. Update all `Kralizek.Lambda.*` runtime packages used by the function to the same v6 version.
+3. Keep `Kralizek.Lambda.Template` for source-neutral Request/Event functions. Use the dedicated v6 package for AWS integrations such as SQS and SNS.
+4. Put the handler type in the function base-class generic arguments. The primary handler is registered automatically.
+5. Remove `RegisterHandler<THandler>(services)` and the v5 source-specific `Use...Handler(...)` registration calls.
+6. Change handler methods to the v6 contract: framework context plus `CancellationToken`, normally returning `ValueTask`/`ValueTask<T>`.
+7. Replace normal `ILambdaContext` usage with the v6 framework/source context. Use the AWS context escape hatch only when you actually need the original runtime object.
+8. Update customization hooks:
+   - `Configure(...)` becomes `ConfigureConfiguration(...)`;
+   - `ConfigureLogging(ILoggingBuilder, IExecutionEnvironment)` becomes `ConfigureLogging(ILoggingBuilder)`;
+   - `ConfigureServices(IServiceCollection, IExecutionEnvironment)` becomes `ConfigureServices(IServiceCollection, IConfiguration)`.
+9. Preserve calls to the corresponding `base.Configure...(...)` methods unless you intentionally want to replace framework defaults.
+10. Build and run the function's tests before changing another integration.
 
-For example, once a request handler has been migrated to v6, choosing the lean host is only a hosting change:
+The sections below show the concrete v5-to-v6 transformation for the four most common v5 function shapes.
+
+## Request/response functions
+
+### v5
+
+A v5 request/response function inherited from `RequestResponseFunction<TInput, TOutput>`, registered its handler manually, and implemented `IRequestResponseHandler<TInput, TOutput>`:
 
 ```csharp
-public class Function : RequestFunction<string, string, MyHandler>;
+public sealed class Function : RequestResponseFunction<string, string>
+{
+    protected override void ConfigureServices(
+        IServiceCollection services,
+        IExecutionEnvironment executionEnvironment)
+        => RegisterHandler<ToUpperHandler>(services);
+}
+
+public sealed class ToUpperHandler : IRequestResponseHandler<string, string>
+{
+    public Task<string> HandleAsync(string input, ILambdaContext context)
+        => Task.FromResult(input.ToUpperInvariant());
+}
 ```
 
-becomes:
+### v6
+
+Use `RequestFunction<TInput, TOutput, THandler>` and `IRequestHandler<TInput, TOutput>`:
 
 ```csharp
-public class Function : MinimalRequestFunction<string, string, MyHandler>;
+public sealed class Function
+    : RequestFunction<string, string, ToUpperHandler>;
+
+public sealed class ToUpperHandler : IRequestHandler<string, string>
+{
+    public ValueTask<string> HandleAsync(
+        string input,
+        RequestContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(input.ToUpperInvariant());
+}
 ```
 
-The handler remains unchanged. See [Minimal Hosting](Minimal-Hosting.md) for the exact capability boundary.
+Itemized changes:
 
-For a migration, first identify the invocation semantics, select the matching v6 template/package, move application behavior into the new handler contract, and then restore any custom service registration, decoding, or source-specific failure behavior. Choose Minimal only after determining that the function does not rely on behavior deliberately owned by the full Request/Event host or by a source-specific Record host.
+- `RequestResponseFunction<TInput, TOutput>` -> `RequestFunction<TInput, TOutput, THandler>`.
+- `IRequestResponseHandler<TInput, TOutput>` -> `IRequestHandler<TInput, TOutput>`.
+- Move `THandler` into the function declaration.
+- Delete `RegisterHandler<THandler>(services)`.
+- `ILambdaContext` -> `RequestContext` for normal invocation metadata.
+- Add the supplied `CancellationToken` to application calls that can observe cancellation.
+- `Task<T>` -> `ValueTask<T>` in the handler contract. Async handlers can still use `async ValueTask<T>`.
 
-Because the redesign changes public base classes and handler contracts, migrate and test one Lambda integration at a time rather than attempting a mechanical namespace/package replacement.
+### Full or Minimal host?
 
-## Performance
+After migrating the handler contract, a source-neutral request function can choose either host without changing the handler:
 
-V6 has two different performance profiles because it has two different hosting choices for source-neutral Request/Event functions.
+```csharp
+public sealed class Function
+    : RequestFunction<string, string, ToUpperHandler>;
+```
 
-The **default/full host** provides the complete V6 Request/Event invocation infrastructure, including the framework's internal invocation telemetry path. The **Minimal host** runs the same V6 handler and context contracts through a shorter path when that infrastructure is not needed. Source-specific Record functions continue to use the full source-specific hosts because their record-processing semantics are part of the model rather than optional hosting decoration.
+or:
 
-The current release benchmark snapshot provides the most useful comparison. On its GitHub-hosted runner, the Request benchmark measured:
+```csharp
+public sealed class Function
+    : MinimalRequestFunction<string, string, ToUpperHandler>;
+```
+
+Use the full host by default. Consider Minimal when the function is latency/allocation-sensitive and does not need the full Request host's invocation telemetry infrastructure. See [Minimal Hosting](Minimal-Hosting.md) for the exact boundary.
+
+## Event functions
+
+### v5
+
+A v5 one-way event function inherited from `EventFunction<TInput>`, registered the handler manually, and implemented `IEventHandler<TInput>`:
+
+```csharp
+public sealed class Function : EventFunction<OrderCreated>
+{
+    protected override void ConfigureServices(
+        IServiceCollection services,
+        IExecutionEnvironment executionEnvironment)
+        => RegisterHandler<OrderCreatedHandler>(services);
+}
+
+public sealed class OrderCreatedHandler : IEventHandler<OrderCreated>
+{
+    public Task HandleAsync(OrderCreated input, ILambdaContext context)
+        => Task.CompletedTask;
+}
+```
+
+### v6
+
+The function now names the handler in its generic arguments:
+
+```csharp
+public sealed class Function
+    : EventFunction<OrderCreated, OrderCreatedHandler>;
+
+public sealed class OrderCreatedHandler : IEventHandler<OrderCreated>
+{
+    public ValueTask HandleAsync(
+        OrderCreated input,
+        EventContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.CompletedTask;
+}
+```
+
+Itemized changes:
+
+- `EventFunction<TInput>` -> `EventFunction<TInput, THandler>`.
+- `IEventHandler<TInput>` remains the application concept, but its method signature changes.
+- Move `THandler` into the function declaration.
+- Delete `RegisterHandler<THandler>(services)`.
+- `ILambdaContext` -> `EventContext` for normal invocation metadata.
+- Add the supplied `CancellationToken`.
+- `Task` -> `ValueTask` in the handler contract.
+
+As with Request functions, a source-neutral Event function can use `MinimalEventFunction<TInput, THandler>` after the handler has been migrated if the Minimal hosting boundary fits the function.
+
+## SNS functions
+
+V5 modeled SNS as an Event function plus service-registration extensions. V6 makes SNS a first-class source-specific function model.
+
+### v5
+
+The typical v5 shape was an `EventFunction<SNSEvent>` plus `UseNotificationHandler<TNotification, THandler>()`:
+
+```csharp
+public sealed class Function : EventFunction<SNSEvent>
+{
+    protected override void ConfigureServices(
+        IServiceCollection services,
+        IExecutionEnvironment executionEnvironment)
+    {
+        services.UseNotificationHandler<OrderCreated, OrderCreatedHandler>();
+    }
+}
+```
+
+with an `INotificationHandler<TNotification>` application handler.
+
+### v6: decoded notification
+
+Use `Kralizek.Lambda.Template.Sns` and declare the notification type and handler directly:
+
+```csharp
+public sealed class Function
+    : SnsFunction<OrderCreated, OrderCreatedHandler>;
+
+public sealed class OrderCreatedHandler
+    : ISnsNotificationHandler<OrderCreated>
+{
+    public ValueTask<SnsRecordResult> HandleAsync(
+        OrderCreated notification,
+        SnsNotificationContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(SnsRecordResult.Completed);
+}
+```
+
+Itemized changes:
+
+- `EventFunction<SNSEvent>` -> `SnsFunction<TNotification, THandler>`.
+- `INotificationHandler<TNotification>` -> `ISnsNotificationHandler<TNotification>`.
+- Delete `UseNotificationHandler<TNotification, THandler>()`.
+- The SNS `Message` is decoded for you through `IStringPayloadDecoder<TNotification>`.
+- Return `SnsRecordResult.Completed` when processing completes normally.
+- Use `SnsNotificationContext` for source metadata.
+- If you need the original AWS `SNSEvent.SNSRecord`, call `context.GetSnsRecord()`.
+
+### v6: raw SNS record
+
+If the v5 code depended on the entire SNS record rather than only the decoded `Message`, migrate to the raw variant instead of decoding and rebuilding the envelope yourself:
+
+```csharp
+public sealed class Function
+    : SnsFunction<RawSnsHandler>;
+
+public sealed class RawSnsHandler : ISnsRecordHandler
+{
+    public ValueTask<SnsRecordResult> HandleAsync(
+        SNSEvent.SNSRecord record,
+        SnsRecordContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(SnsRecordResult.Completed);
+}
+```
+
+### SNS parallel execution
+
+V5 enabled parallel processing through:
+
+```csharp
+services
+    .UseNotificationHandler<OrderCreated, OrderCreatedHandler>()
+    .WithParallelExecution(maxDegreeOfParallelism: 4);
+```
+
+In v6, parallel processing is explicit in the function type. Use the corresponding `ParallelSnsFunction<...>` variant and configure its supported degree of parallelism rather than chaining a registration extension.
+
+Sequential processing is the default.
+
+### SNS custom serialization
+
+V5 custom serializers implemented `INotificationSerializer` and were registered with `UseCustomNotificationSerializer<TSerializer>()`.
+
+In v6, replace that serializer with an `IStringPayloadDecoder<TNotification>` implementation and register it through dependency injection. JSON decoding is already registered by default.
+
+SNS still has no Lambda partial-batch response. If decoding or handling a record throws, the invocation fails and AWS applies normal SNS/Lambda retry behavior.
+
+## SQS functions
+
+V5 modeled SQS through generic Event/RequestResponse infrastructure plus SQS registration helpers. V6 makes record processing, decoding, record scopes, and partial-batch results explicit.
+
+### v5
+
+A typical typed v5 function registered a queue-message handler:
+
+```csharp
+public sealed class Function : EventFunction<SQSEvent>
+{
+    protected override void ConfigureServices(
+        IServiceCollection services,
+        IExecutionEnvironment executionEnvironment)
+    {
+        services.UseQueueMessageHandler<OrderCreated, OrderCreatedHandler>();
+    }
+}
+```
+
+with an `IMessageHandler<TMessage>` application handler.
+
+Some v5 functions instead used `RequestResponseFunction<SQSEvent, SQSBatchResponse>` directly and built `BatchItemFailures` themselves.
+
+### v6: decoded message
+
+Use `Kralizek.Lambda.Template.Sqs` and declare the body type and handler directly:
+
+```csharp
+public sealed class Function
+    : SqsFunction<OrderCreated, OrderCreatedHandler>;
+
+public sealed class OrderCreatedHandler
+    : ISqsMessageHandler<OrderCreated>
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        OrderCreated message,
+        SqsMessageContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(SqsRecordResult.Success);
+}
+```
+
+Itemized changes:
+
+- Generic `EventFunction<SQSEvent>` / hand-written `RequestResponseFunction<SQSEvent, SQSBatchResponse>` -> `SqsFunction<TMessage, THandler>`.
+- `IMessageHandler<TMessage>` -> `ISqsMessageHandler<TMessage>`.
+- Delete `UseQueueMessageHandler<TMessage, THandler>()` and `RegisterHandler<THandler>()`.
+- The SQS body is decoded through `IStringPayloadDecoder<TMessage>`.
+- Return `SqsRecordResult.Success` for a successful record.
+- Return `SqsRecordResult.Failed(reason)` for a record that must appear in `batchItemFailures`.
+- Use `SqsMessageContext` for source metadata.
+- If you need the original `SQSEvent.SQSMessage`, call `context.GetSqsMessage()`.
+
+### v6: raw SQS record
+
+If your v5 handler worked with the original record, use the raw variant:
+
+```csharp
+public sealed class Function
+    : SqsFunction<RawSqsHandler>;
+
+public sealed class RawSqsHandler : ISqsRecordHandler
+{
+    public ValueTask<SqsRecordResult> HandleAsync(
+        SQSEvent.SQSMessage record,
+        SqsRecordContext context,
+        CancellationToken cancellationToken)
+        => ValueTask.FromResult(SqsRecordResult.Success);
+}
+```
+
+### Replace hand-built `SQSBatchResponse`
+
+If a v5 function manually iterated the batch and constructed `SQSBatchResponse`, move the per-record behavior into the v6 handler and return a record result instead.
+
+v5:
+
+```csharp
+foreach (var record in input.Records)
+{
+    try
+    {
+        await ProcessAsync(record);
+    }
+    catch (Exception)
+    {
+        failures.Add(new SQSBatchResponse.BatchItemFailure
+        {
+            ItemIdentifier = record.MessageId
+        });
+    }
+}
+
+return new SQSBatchResponse
+{
+    BatchItemFailures = failures
+};
+```
+
+v6:
+
+```csharp
+public async ValueTask<SqsRecordResult> HandleAsync(
+    OrderCreated message,
+    SqsMessageContext context,
+    CancellationToken cancellationToken)
+{
+    var processed = await ProcessAsync(message, cancellationToken);
+
+    return processed
+        ? SqsRecordResult.Success
+        : SqsRecordResult.Failed("Message could not be processed.");
+}
+```
+
+The SQS host owns the final `SQSBatchResponse` aggregation.
+
+### SQS parallel execution
+
+V5 enabled in-process parallelism with:
+
+```csharp
+services
+    .UseQueueMessageHandler<OrderCreated, OrderCreatedHandler>()
+    .WithParallelExecution(maxDegreeOfParallelism: 4);
+```
+
+In v6, choose the corresponding `ParallelSqsFunction<...>` variant. Sequential processing is the default.
+
+### SQS custom serialization
+
+V5 custom serializers implemented `IMessageSerializer` and were registered with `UseCustomMessageSerializer<TSerializer>()`.
+
+In v6, replace that serializer with `IStringPayloadDecoder<TMessage>` and register the decoder through dependency injection. JSON decoding is registered by default.
+
+### Infrastructure check: partial batch response
+
+The v6 code can produce partial-batch failures, but the Lambda event source mapping must still have `ReportBatchItemFailures` enabled. Do not treat this as an application-code-only migration.
+
+Also review the event source mapping's batch size, retry/DLQ behavior, concurrency settings, and visibility timeout while validating the migrated function.
+
+## Configuration, logging, and services
+
+A common v5 function combined handler registration with application customization:
+
+```csharp
+protected override void Configure(IConfigurationBuilder configuration)
+{
+    configuration.AddEnvironmentVariables();
+}
+
+protected override void ConfigureLogging(
+    ILoggingBuilder logging,
+    IExecutionEnvironment executionEnvironment)
+{
+    // ...
+}
+
+protected override void ConfigureServices(
+    IServiceCollection services,
+    IExecutionEnvironment executionEnvironment)
+{
+    services.AddScoped<IMyService, MyService>();
+    RegisterHandler<MyHandler>(services);
+}
+```
+
+The equivalent v6 customization is:
+
+```csharp
+protected override void ConfigureConfiguration(
+    IConfigurationBuilder configuration)
+{
+    configuration.AddEnvironmentVariables();
+    base.ConfigureConfiguration(configuration);
+}
+
+protected override void ConfigureLogging(ILoggingBuilder logging)
+{
+    // Add or customize logging here.
+    base.ConfigureLogging(logging);
+}
+
+protected override void ConfigureServices(
+    IServiceCollection services,
+    IConfiguration configuration)
+{
+    services.AddScoped<IMyService, MyService>();
+    base.ConfigureServices(services, configuration);
+}
+```
+
+Do not register the primary handler unless you intentionally want to override its default scoped lifetime.
+
+Lambda-compatible logging is configured by the framework, so existing `ILogger<T>` dependencies normally require less bootstrap code than in v5.
+
+## `ILambdaContext` migration
+
+Do not mechanically inject the original `ILambdaContext` into every v6 handler just because the v5 handler received it.
+
+Use the supplied v6 context first:
+
+- `RequestContext` for Request functions;
+- `EventContext` for Event functions;
+- `SqsMessageContext` / `SqsRecordContext` for SQS;
+- `SnsNotificationContext` / `SnsRecordContext` for SNS.
+
+These contexts expose the stable invocation/source metadata expected by application code. Source-specific contexts also preserve the original AWS records through escape-hatch extensions when needed.
+
+If application code intentionally requires something that is only available from the AWS runtime context, use the framework's AWS-context escape hatch rather than making the AWS object the default application abstraction.
+
+## Handler lifetime and scopes
+
+V5 users often registered handlers themselves, which made the lifetime part of application setup.
+
+In v6:
+
+- the primary handler is registered automatically as scoped;
+- Request/Event hosts create one DI scope per invocation;
+- SQS/SNS create one DI scope per record;
+- source-specific parallel variants may therefore execute multiple independent record scopes concurrently.
+
+Review dependencies that were accidentally relying on a singleton or invocation-wide lifetime when migrating SQS/SNS handlers.
+
+## Payload decoding
+
+V5 had source-specific serialization hooks:
+
+- `INotificationSerializer` for SNS;
+- `IMessageSerializer` for SQS.
+
+V6 uses the common payload-decoder abstraction:
+
+```csharp
+public sealed class OrderCreatedDecoder
+    : IStringPayloadDecoder<OrderCreated>
+{
+    public ValueTask<OrderCreated> DecodeAsync(
+        string payload,
+        CancellationToken cancellationToken)
+    {
+        // Decode the payload.
+    }
+}
+```
+
+Register your decoder through DI. The v6 source package supplies JSON decoding by default, including a path for source-generated System.Text.Json metadata in Native AOT functions.
+
+## Package and template changes
+
+The v5 Empty/Rich template split is gone. V6 templates are organized by semantic function model and AWS event source.
+
+Install the v6 templates and inspect the current catalog:
+
+```bash
+dotnet new install Kralizek.Lambda.Templates
+
+dotnet new list lambda-template
+```
+
+For an existing project, using a freshly generated v6 project of the same function type as a reference is often the fastest way to compare package references, serializer/bootstrap code, and deployment settings.
+
+## Migration verification checklist
+
+Before considering one function migrated, verify all of the following:
+
+- [ ] project targets .NET 10;
+- [ ] all Kralizek runtime packages use the same v6 version;
+- [ ] function base class matches its invocation semantics/source;
+- [ ] primary handler is declared in the function type;
+- [ ] old handler registration calls are removed;
+- [ ] handler implements the v6 contract and accepts cancellation;
+- [ ] direct `ILambdaContext` usage has been reviewed rather than blindly carried over;
+- [ ] configuration/logging/service overrides use the v6 signatures;
+- [ ] custom SNS/SQS serializers have become payload decoders;
+- [ ] SQS handlers return explicit success/failure results;
+- [ ] SQS event source mapping has `ReportBatchItemFailures` configured when partial-batch behavior is expected;
+- [ ] previous parallel-processing behavior has been deliberately restored, if needed;
+- [ ] DI lifetime assumptions still hold with v6 invocation/record scopes;
+- [ ] unit/integration tests exercise successful and failing records;
+- [ ] deployment package and Lambda runtime are .NET 10-compatible.
+
+## Performance and choosing Minimal
+
+V6 has two hosting choices for source-neutral Request/Event functions. The full host provides the complete v6 invocation infrastructure. Minimal runs the same handler/context programming model through a shorter path when that infrastructure is not needed.
+
+The current release benchmark snapshot measured the following Request workload on its GitHub-hosted runner:
 
 | Model | Mean | Allocated |
 | --- | ---: | ---: |
@@ -48,9 +531,7 @@ The current release benchmark snapshot provides the most useful comparison. On i
 | V6 Minimal | 299.6 ns | 584 B |
 | V6 full | 443.0 ns | 712 B |
 
-The Request workload intentionally does almost no application work, so it magnifies framework overhead. In that run, Minimal reduced the V6 hosting cost substantially: it was about 32% faster than the full V6 host and allocated 128 B less per invocation. Compared with V5, Minimal still had a measurable floor: roughly 103 ns and 232 B per invocation on this synthetic workload.
-
-A nested SQS -> SNS -> S3 workload gives a different view because event-processing work dominates more of the invocation. The current release snapshot measured:
+A nested SQS -> SNS -> S3 workload measured:
 
 | Model | Mean | Allocated |
 | --- | ---: | ---: |
@@ -59,15 +540,20 @@ A nested SQS -> SNS -> S3 workload gives a different view because event-processi
 | V6 Minimal comparison | 5.88 us | 4,624 B |
 | V6 full/source-specific | 7.93 us | 6,088 B |
 
-The Minimal contender in record-oriented benchmark suites is a comparison fixture rather than a `MinimalSqsFunction` or other source-specific Minimal host. It deliberately keeps the Minimal Request/Event hosting model while moving AWS-specific iteration, decoding, failure translation, and nested envelope processing back into application code. This makes the benchmark useful for showing the boundary between lean V6 hosting and framework-owned AWS orchestration, but it is not a second source-specific hosting API.
+The Minimal contender in record-oriented benchmarks is a comparison fixture, not a `MinimalSqsFunction` or `MinimalSnsFunction`. It moves AWS-specific iteration, decoding, and failure translation back into application code so the benchmark can isolate hosting overhead.
 
-These measurements should be interpreted as architectural comparisons rather than universal throughput ratios. GitHub-hosted runners are useful for release-to-release trends but are not controlled benchmark hardware, and very small timing measurements are especially sensitive to run-to-run variation. Allocation differences are much more stable. For latency- or allocation-sensitive functions, benchmark the actual workload.
+Treat these measurements as architectural comparisons, not universal throughput ratios. Benchmark the actual workload when latency or allocations matter.
 
-The practical migration guidance is therefore:
+See [the benchmark documentation](../benchmarks/README.md) for methodology and release benchmark history.
 
-- choose the full V6 host when the function benefits from the complete V6 invocation infrastructure or source-specific Record semantics;
-- choose Minimal for source-neutral Request/Event functions that want the V6 handler/context/DI programming model with less hosting overhead;
-- do not treat Minimal as a compatibility mode or as evidence that the full V6 model is incorrect;
-- expect the relative overhead to shrink as real application work becomes more significant than the framework floor.
+## Related documentation
 
-See [the benchmark documentation](../benchmarks/README.md) for methodology, controlled measurements, release benchmark history, and the broader benchmark matrix.
+- [Request Functions](Request-Functions.md)
+- [Event Functions](Event-Functions.md)
+- [SQS](SQS.md)
+- [SNS](SNS.md)
+- [Function Contexts](Function-Contexts.md)
+- [Payload Decoding](Payload-Decoding.md)
+- [Record Processing](Record-Processing.md)
+- [Customization](Customization.md)
+- [Minimal Hosting](Minimal-Hosting.md)


### PR DESCRIPTION
## Summary

Adds a concrete, consumer-facing v5 -> v6 upgrade guide ahead of the v6 release.

The guide is organized around mechanical migrations rather than architecture-only discussion and includes before/after code for:

- Request/response functions
- Event functions
- SNS functions (typed/raw, parallelism, custom decoding)
- SQS functions (typed/raw, partial batch responses, parallelism, custom decoding)
- configuration, logging and DI hook changes
- `ILambdaContext` replacement and handler scope/lifetime changes
- full vs Minimal hosting

The root `MIGRATION.md` now points to the detailed guide to avoid maintaining two competing migration documents.

## Validation

Documentation-only change. API names and signatures were checked against the current v6 handler/function implementations, including the raw SNS/SQS context types and parallel function variants.