### PR TITLE
Prepare v6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [6.0.0] - Unreleased
+## [6.0.0] - 2026-08-26
 
 Version 6 is a major redesign of the library and template set. It replaces the V5 programming model with semantic function types, expands the supported AWS event sources, and moves the project to .NET 10.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet new list lambda-template
 
 See [Project Templates](docs/Project-Templates.md) for the supported templates and when to use each one.
 
-The template options are independent where supported: `--raw` chooses the record/payload shape, `--aot` chooses executable hosting and source-generated Lambda serialization, and `--otel` adds Lambda invocation instrumentation.
+The template options are independent where supported: `--minimal` selects lean hosting for source-neutral Request/Event templates, `--raw` chooses the record/payload shape, `--aot` chooses executable hosting and source-generated Lambda serialization, and `--otel` adds Lambda invocation instrumentation.
 
 ## Package family
 
@@ -47,7 +47,12 @@ The template package and all runtime packages use the same package version for a
 ## Documentation
 
 - [Getting Started](docs/Getting-Started.md)
+- [Choosing a Function Model](docs/Choosing-a-Function-Model.md)
 - [Programming Model](docs/Programming-Model.md)
+- [Project Templates](docs/Project-Templates.md)
+- [Minimal Hosting](docs/Minimal-Hosting.md)
+- [Native AOT](docs/Native-AOT.md)
+- [OpenTelemetry](docs/OpenTelemetry.md)
 - [Payload Decoding](docs/Payload-Decoding.md)
 - [Record Processing](docs/Record-Processing.md)
 - [AWS integrations](docs/README.md#start-here)

--- a/src/Kralizek.Lambda.Template.Abstractions/Kralizek.Lambda.Template.Abstractions.csproj
+++ b/src/Kralizek.Lambda.Template.Abstractions/Kralizek.Lambda.Template.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.Abstractions</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp</PackageTags>
-    <Description>Lightweight handler, context, and payload decoder contracts for Kralizek.Lambda.Template.</Description>
+    <Description>Runtime-independent handler contracts, function contexts, record results, and payload decoders for Kralizek.Lambda.Template.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.Cognito/Kralizek.Lambda.Template.Cognito.csproj
+++ b/src/Kralizek.Lambda.Template.Cognito/Kralizek.Lambda.Template.Cognito.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.Cognito</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;cognito</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for Amazon Cognito user pool Lambda triggers.</Description>
+    <Description>Amazon Cognito User Pool Lambda trigger specializations and strongly typed handler contracts.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.DynamoDbStreams/Kralizek.Lambda.Template.DynamoDbStreams.csproj
+++ b/src/Kralizek.Lambda.Template.DynamoDbStreams/Kralizek.Lambda.Template.DynamoDbStreams.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.DynamoDbStreams</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;dynamodb;streams</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by Amazon DynamoDB Streams.</Description>
+    <Description>DynamoDB Streams record processing with source-specific contexts and partial-batch failure responses.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.EventBridge/Kralizek.Lambda.Template.EventBridge.csproj
+++ b/src/Kralizek.Lambda.Template.EventBridge/Kralizek.Lambda.Template.EventBridge.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.EventBridge</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;eventbridge</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by Amazon EventBridge.</Description>
+    <Description>Amazon EventBridge function model with strongly typed event detail and access to the complete AWS event envelope.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.KinesisStreams/Kralizek.Lambda.Template.KinesisStreams.csproj
+++ b/src/Kralizek.Lambda.Template.KinesisStreams/Kralizek.Lambda.Template.KinesisStreams.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.KinesisStreams</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;kinesis;streams</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by Amazon Kinesis Data Streams.</Description>
+    <Description>Kinesis Data Streams record processing with raw or decoded payloads and partial-batch failure responses.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.S3/Kralizek.Lambda.Template.S3.csproj
+++ b/src/Kralizek.Lambda.Template.S3/Kralizek.Lambda.Template.S3.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.S3</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;s3</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by Amazon S3.</Description>
+    <Description>Amazon S3 event notification and S3 Batch Operations function models with source-specific contexts and results.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.Sns/Kralizek.Lambda.Template.Sns.csproj
+++ b/src/Kralizek.Lambda.Template.Sns/Kralizek.Lambda.Template.Sns.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.Sns</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;sns</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by SNS.</Description>
+    <Description>Amazon SNS notification processing with raw or decoded payloads and bounded parallel execution support.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template.Sqs/Kralizek.Lambda.Template.Sqs.csproj
+++ b/src/Kralizek.Lambda.Template.Sqs/Kralizek.Lambda.Template.Sqs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template.Sqs</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp;sqs</PackageTags>
-    <Description>Extension to Kralizek.Lambda.Template for AWS Lambda functions triggered by SQS.</Description>
+    <Description>Amazon SQS message processing with raw or decoded payloads, bounded parallel execution, and partial-batch failure responses.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Kralizek.Lambda.Template/Kralizek.Lambda.Template.csproj
+++ b/src/Kralizek.Lambda.Template/Kralizek.Lambda.Template.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Template</PackageId>
     <PackageTags>aws-lambda-csharp;dotnet-core;aws-lambda;aws;lambda;csharp</PackageTags>
-    <Description>A structured template to create AWS Lambda in C#. It supports Logging, Dependency Injection and Configuration like ASP.NET Core projects do.</Description>
+    <Description>Core runtime for AWS Lambda functions using the Event, Request, and Record programming models, with dependency injection, configuration, logging, cancellation, and framework telemetry.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/templates/Kralizek.Lambda.Templates.csproj
+++ b/templates/Kralizek.Lambda.Templates.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <PackageId>Kralizek.Lambda.Templates</PackageId>
     <PackageType>Template</PackageType>
-    <Description>Templates for AWS Lambda using Kralizek.Lambda.Template</Description>
+    <Description>dotnet new project templates for .NET 10 AWS Lambda functions using Kralizek.Lambda.Template and its source-specific integrations.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSymbols>false</IncludeSymbols>

--- a/templates/README.md
+++ b/templates/README.md
@@ -24,6 +24,7 @@ dotnet new list lambda-template
 | Request Function | `lambda-template-request` | The Lambda handles an input and returns an application result. |
 | EventBridge Function | `lambda-template-eventbridge` | The Lambda is targeted by EventBridge and receives a strongly typed event detail inside the AWS event envelope. |
 | DynamoDB Streams Function | `lambda-template-dynamodb-stream` | The Lambda consumes DynamoDB Streams records with source-specific context and partial-batch failure support. |
+| Kinesis Streams Function | `lambda-template-kinesis-stream` | The Lambda consumes Kinesis Data Streams records as raw AWS records or decoded binary payloads with partial-batch failure support. |
 | S3 Function | `lambda-template-s3` | The Lambda reacts to native S3 event notifications using a synthetic object-event model. |
 | S3 Batch Function | `lambda-template-s3-batch` | The Lambda processes S3 Batch Operations tasks using invocation schema 2.0. |
 | SNS Function | `lambda-template-sns` | The Lambda is triggered by SNS and processes each decoded notification independently. |
@@ -65,6 +66,12 @@ Create a DynamoDB Streams function:
 
 ```bash
 dotnet new lambda-template-dynamodb-stream --name MyDynamoDbStreamFunction
+```
+
+Create a Kinesis Streams function:
+
+```bash
+dotnet new lambda-template-kinesis-stream --name MyKinesisStreamFunction
 ```
 
 Create an S3 notification function:
@@ -155,6 +162,14 @@ public sealed class Function : DynamoDbStreamFunction<OrderChangeHandler>;
 ```
 
 The handler receives a `DynamoDbStreamItem` containing keys, old/new images, sequence number and stream metadata together with `DynamoDbStreamRecordContext` for the outer event metadata. The original AWS stream record remains available through `context.GetDynamoDbStreamRecord()`. DynamoDB images remain in AWS's `DynamoDBEvent.AttributeValue` model rather than being treated as JSON. Record failures are translated into `StreamsEventResponse` partial-batch failures; the event-source mapping must enable `ReportBatchItemFailures` for Lambda to honor them. Records are processed sequentially within each invocation; applications that need more throughput should configure `ParallelizationFactor` on the DynamoDB Streams event-source mapping.
+
+A Kinesis Streams Function derives from `KinesisStreamFunction<TPayload, THandler>` for decoded payloads or `KinesisStreamFunction<THandler>` for raw AWS records:
+
+```csharp
+public sealed class Function : KinesisStreamFunction<OrderCreated, OrderCreatedHandler>;
+```
+
+Typed handlers decode `KinesisEventRecord.Kinesis.Data` through `IBinaryPayloadDecoder<TPayload>`, with System.Text.Json registered by default. Failed records are translated into `StreamsEventResponse` partial-batch failures using Kinesis sequence numbers; the event-source mapping must enable `ReportBatchItemFailures` for Lambda to honor them. Records are processed sequentially within each invocation, leaving concurrency such as `ParallelizationFactor` to the event source mapping.
 
 An S3 Function derives from `S3Function<THandler>` and invokes an `IS3ObjectEventHandler` for each native S3 notification record:
 


### PR DESCRIPTION
## Summary

Prepare the repository for the v6.0.0 GA release without changing runtime behavior.

- finalize the v6.0.0 changelog date;
- document `--minimal` and surface the main v6 guides from the root README;
- complete the template package README with the shipped Kinesis Streams template, creation example, and programming model;
- refresh NuGet package descriptions across the runtime and template package family so they describe the v6 APIs and capabilities rather than the old extension/template framing.

## How it was tested

- reviewed the branch diff against `master` to verify the changes are limited to documentation and NuGet package descriptions;
- cross-checked the Kinesis README additions against `docs/Kinesis-Streams.md`;
- full build, pack, and template smoke-test validation is left to the existing PR CI.

## Checklist

- [x] Tests added or updated for changed behaviour — not applicable; there are no behavior changes
- [x] Documentation updated where relevant
- [x] Package/template/sample/smoke-test coverage kept aligned where applicable
- [x] AWS batching, retry, ordering, and event-source semantics preserved where applicable
- [x] No unrelated changes included
- [x] CI is green
